### PR TITLE
Create 0.0.7

### DIFF
--- a/bridgebots/CHANGELOG.md
+++ b/bridgebots/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [0.0.7] - 2021-11-27
 ### Added
-- BoardRecord and BoardRecord schema have better handling of missing commentary or bidding metadata
+- Utility method `calculate_score` to compute the scoring of a hand
+- `Contract` dataclass for programmatic interaction with contracts [Issue #6](https://github.com/forrestrice/bridge-bots/issues/6)
+### Changed
+- Methods which take each suit as an argument specify arguments in descending suit order (Spades, Hearts, Diamonds, Clubs) to match common convention. [Issue #7](https://github.com/forrestrice/bridge-bots/issues/7)
+- Consolidated all submodule imports under `__init__.py`. Users can now simply `import bridgebots`. [Issue #8](https://github.com/forrestrice/bridge-bots/issues/8)
+- All Record classes (BoardRecord, DealRecord, etc) now implemented as [dataclasses](https://docs.python.org/3/library/dataclasses.html). [Issue #9](https://github.com/forrestrice/bridge-bots/issues/9)
+
 
 ## [0.0.6] - 2021-09-06
 ### Changed

--- a/bridgebots/CHANGELOG.md
+++ b/bridgebots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.7] - 2021-11-27
+### Added
+- BoardRecord and BoardRecord schema have better handling of missing commentary or bidding metadata
+
 ## [0.0.6] - 2021-09-06
 ### Changed
 - BoardRecord and BoardRecord schema have better handling of missing commentary or bidding metadata

--- a/bridgebots/README.md
+++ b/bridgebots/README.md
@@ -29,12 +29,25 @@ Use type-hints wherever possible.
 
 Any added functionality should include unit tests.
 
+## Guides
+There are a few introductory guides with detailed examples available.
+1. [Representing Bridge Components](https://forrestrice.com/posts/Announcing-Bridgebots/)
+2. [Deal/Board Records and PBN files](https://forrestrice.com/posts/Introducing-Bridgebots-Part-2/)
+3. LIN files and JSON (forthcoming)
+
+
 ## Examples
-Examples are mostly provided in a python console format to show the structure of data. Imports are omitted for brevity; see the unit tests for more details.
+Examples are mostly provided in a python console format  to show the structure of data. Begin by importing:
+```pycon
+import bridgebots
+from bridgebots import Card, Deal, DealRecord, DealRecordSchema, Direction, PlayerHand, Rank, Suit
+from pathlib import Path 
+from typing import List
+```
 ### Deal
 Construct a deal manually
-```python
-hands = {
+```pycon
+>>> hands = {
     Direction.NORTH: PlayerHand.from_string_lists(
         ["9", "8", "6", "4"], ["K", "Q", "7", "6", "3"], ["A", "K"], ["7", "3"]
     ),
@@ -48,12 +61,12 @@ hands = {
         ["J", "10", "7", "3"], [], ["10", "9", "6"], ["Q", "J", "9", "6", "5", "2"]
     ),
 }
-deal = Deal(dealer=Direction.EAST, ns_vulnerable=True, ew_vulnerable=False, hands=hands)
+>>> deal = Deal(dealer=Direction.EAST, ns_vulnerable=True, ew_vulnerable=False, hands=hands)
 ```
 
 Construct a deal from a PBN style string
 ```python
-deal = deal_utils.from_pbn_deal("N", "EW", "W:Q8652.875.943.AT J97.AJ2.AKQ2.Q87 AK.QT943.87.9632 T43.K6.JT65.KJ54")
+>>> deal = bridgebots.from_pbn_deal("N", "EW", "W:Q8652.875.943.AT J97.AJ2.AKQ2.Q87 AK.QT943.87.9632 T43.K6.JT65.KJ54")
 ```
 
 Interact with a Bridgebots deal
@@ -76,7 +89,7 @@ True
 Parse a Version 1.0 PBN file into Bridgebots Deal and BoardRecord objects.
 ```pycon
 >>> pbn_path = Path("bridgebots/tests/resources/sample.pbn")
->>> results: List[DealRecord] = pbn.parse_pbn(pbn_path)
+>>> results: List[DealRecord] = bridgebots.parse_pbn(pbn_path)
 >>> print(results[0].deal)
 Deal(
 	dealer=Direction.EAST, ns_vulnerable=True, ew_vulnerable=True
@@ -87,23 +100,14 @@ Deal(
 )
 
 >>> print(results[0].board_records[0])
-BoardRecord(
-	bidding_record=['1H', 'PASS', '1S', 'PASS', '2C', 'PASS', '2H', 'PASS', '2S', 'PASS', '3NT', 'PASS', 'PASS', 'PASS'],
-	raw_bidding_record=['1H', 'Pass', '1S', '=1=', 'Pass', '2C', '!', 'Pass', '2H', '=2=', 'Pass', '2S', '=3=', 'Pass', '3NT', 'AP'],
-	play_record=[CQ, CA, C8, C3, H4, HT, HK, H6, H3, H2, HQ, HA, C5, C6, CK, CT, D4, DJ, DQ, DK, CJ, C2, S7, C7, C9, C4, H5, S4, S6],
-	declarer=Direction.WEST, contract=3NT, tricks=9, scoring=IMP;Cross,
-	names={NORTH: '', SOUTH: '', EAST: '', WEST: ''},
-	date=2004.05.05, event=Cavendish Pairs Day 2,
-	bidding_metadata=[BidMetadata(bid_index=2, bid=1S, alerted=False, explanation=0-4 !ss), BidMetadata(bid_index=4, bid=2C, alerted=True, explanation=None), BidMetadata(bid_index=6, bid=2H, alerted=False, explanation=less than 8 points), BidMetadata(bid_index=8, bid=2S, alerted=False, explanation=17+ with 4 !S)],
-	commentary=None)
-)
+BoardRecord(bidding_record=['1H', 'PASS', '1S', 'PASS', '2C', 'PASS', '2H', 'PASS', '2S', 'PASS', '3NT', 'PASS', 'PASS', 'PASS'], raw_bidding_record=['1H', 'Pass', '1S', '=1=', 'Pass', '2C', '!', 'Pass', '2H', '=2=', 'Pass', '2S', '=3=', 'Pass', '3NT', 'AP'], play_record=[CQ, CA, C8, C3, H4, HT, HK, H6, H3, H2, HQ, HA, C5, C6, CK, CT, D4, DJ, DQ, DK, CJ, C2, S7, C7, C9, C4, H5, S4, S6], declarer=WEST, contract=Contract(level=3, suit=NO_TRUMP, doubled=0), tricks=9, scoring='IMP;Cross', names={NORTH: '', SOUTH: '', EAST: '', WEST: ''}, date='2004.05.05', event='Cavendish Pairs Day 2', bidding_metadata=[BidMetadata(bid_index=2, bid='1S', alerted=False, explanation='0-4 !ss'), BidMetadata(bid_index=4, bid='2C', alerted=True, explanation=None), BidMetadata(bid_index=6, bid='2H', alerted=False, explanation='less than 8 points'), BidMetadata(bid_index=8, bid='2S', alerted=False, explanation='17+ with 4 !S')], commentary=None, score=600)
 ```
 ### LIN
 #### Parsing
 Parse a BBO LIN record.
 ```pycon
 >>> lin_path = Path("bridgebots/tests/resources/sample.lin")
->>> results: List[DealRecord] = lin.parse_single(lin_path)
+>>> results: List[DealRecord] = bridgebots.parse_single_lin(lin_path)
 >>> print(results[0].deal)
 Deal(
 	dealer=Direction.SOUTH, ns_vulnerable=True, ew_vulnerable=False
@@ -114,27 +118,18 @@ Deal(
 )
 
 >>> print(results[0].board_records[0])
-BoardRecord(
-	bidding_record=['PASS', '1H', '2NT', 'PASS', '3NT', 'PASS', 'PASS', 'PASS'],
-	raw_bidding_record=['p', '1H', '2N', 'p', '3N', 'p', 'p', 'p'],
-	play_record=[H4, H2, HJ, HA, DA, D4, D3, S3, DJ, D8, D6, S4, DT, D9, D7, S6, D2, C3, DK, SJ, DQ, C4, D5, S7, S2, H3, SK, SA, HT, HQ, HK, C2, H5, S5, H9, H8, C5, CT, CA, C6, H7, C7, ST, S8, H6, C9, C8, S9, CQ, CJ, CK, SQ],
-	declarer=Direction.NORTH, contract=3NT, tricks=6, scoring=None,
-	names={SOUTH: 'PrinceBen', WEST: 'Forrest_', NORTH: 'smalark', EAST: 'granola357'},
-	date=None, event=None,
-	bidding_metadata=[BidMetadata(bid_index=2, bid=2NT, alerted=False, explanation=Unusual No Trump: 2 5card minors)],
-	commentary=None)
-)
+BoardRecord(bidding_record=['PASS', '1H', '2NT', 'PASS', '3NT', 'PASS', 'PASS', 'PASS'], raw_bidding_record=['p', '1H', '2N', 'p', '3N', 'p', 'p', 'p'], play_record=[H4, H2, HJ, HA, DA, D4, D3, S3, DJ, D8, D6, S4, DT, D9, D7, S6, D2, C3, DK, SJ, DQ, C4, D5, S7, S2, H3, SK, SA, HT, HQ, HK, C2, H5, S5, H9, H8, C5, CT, CA, C6, H7, C7, ST, S8, H6, C9, C8, S9, CQ, CJ, CK, SQ], declarer=NORTH, contract=Contract(level=3, suit=NO_TRUMP, doubled=0), tricks=6, scoring=None, names={SOUTH: 'PrinceBen', WEST: 'Forrest_', NORTH: 'smalark', EAST: 'granola357'}, date=None, event=None, bidding_metadata=[BidMetadata(bid_index=2, bid='2NT', alerted=False, explanation='Unusual No Trump: 2 5card minors')], commentary=None, score=-300)
 ```
 BBO multi-board LIN records are also supported using `parse_multi`
 #### Creating
 Create a BBO LIN string or URL
 ```pycon
 >>> lin_path = Path("bridgebots/tests/resources/sample.lin")
->>> results: List[DealRecord] = lin.parse_single(lin_path)
->>> lin.build_lin_str(results[0].deal, results[0].board_records[0])
+>>> results: List[DealRecord] = bridgebots.parse_single_lin(lin_path)
+>>> bridgebots.build_lin_str(results[0].deal, results[0].board_records[0])
 pn|PrinceBen,Forrest_,smalark,granola357|st||md|1SQ982HQ82DKQ763CT,SJ643HKJ7653DCAQ4,SK5HADAJT52CJ9762,SAT7HT94D984CK853|sv|n|mb|p|mb|1H|mb|2N|an|Unusual No Trump: 2 5card minors|mb|p|mb|3N|mb|p|mb|p|mb|p|pg||pc|H4|pc|H2|pc|HJ|pc|HA|pg||pc|DA|pc|D4|pc|D3|pc|S3|pg||pc|DJ|pc|D8|pc|D6|pc|S4|pg||pc|DT|pc|D9|pc|D7|pc|S6|pg||pc|D2|pc|C3|pc|DK|pc|SJ|pg||pc|DQ|pc|C4|pc|D5|pc|S7|pg||pc|S2|pc|H3|pc|SK|pc|SA|pg||pc|HT|pc|HQ|pc|HK|pc|C2|pg||pc|H5|pc|S5|pc|H9|pc|H8|pg||pc|C5|pc|CT|pc|CA|pc|C6|pg||pc|H7|pc|C7|pc|ST|pc|S8|pg||pc|H6|pc|C9|pc|C8|pc|S9|pg||pc|CQ|pc|CJ|pc|CK|pc|SQ|pg||pg||
 
->>> lin.build_lin_url(results[0].deal, results[0].board_records[0])
+>>> bridgebots.build_lin_url(results[0].deal, results[0].board_records[0])
 'https://www.bridgebase.com/tools/handviewer.html?lin=pn%7CPrinceBen%2CForrest_%2Csmalark%2Cgranola357%7Cst%7C%7Cmd%7C1SQ982HQ82DKQ763CT%2CSJ643HKJ7653DCAQ4%2CSK5HADAJT52CJ9762%2CSAT7HT94D984CK853%7Csv%7Cn%7Cmb%7Cp%7Cmb%7C1H%7Cmb%7C2N%7Can%7CUnusual+No+Trump%3A+2+5card+minors%7Cmb%7Cp%7Cmb%7C3N%7Cmb%7Cp%7Cmb%7Cp%7Cmb%7Cp%7Cpg%7C%7Cpc%7CH4%7Cpc%7CH2%7Cpc%7CHJ%7Cpc%7CHA%7Cpg%7C%7Cpc%7CDA%7Cpc%7CD4%7Cpc%7CD3%7Cpc%7CS3%7Cpg%7C%7Cpc%7CDJ%7Cpc%7CD8%7Cpc%7CD6%7Cpc%7CS4%7Cpg%7C%7Cpc%7CDT%7Cpc%7CD9%7Cpc%7CD7%7Cpc%7CS6%7Cpg%7C%7Cpc%7CD2%7Cpc%7CC3%7Cpc%7CDK%7Cpc%7CSJ%7Cpg%7C%7Cpc%7CDQ%7Cpc%7CC4%7Cpc%7CD5%7Cpc%7CS7%7Cpg%7C%7Cpc%7CS2%7Cpc%7CH3%7Cpc%7CSK%7Cpc%7CSA%7Cpg%7C%7Cpc%7CHT%7Cpc%7CHQ%7Cpc%7CHK%7Cpc%7CC2%7Cpg%7C%7Cpc%7CH5%7Cpc%7CS5%7Cpc%7CH9%7Cpc%7CH8%7Cpg%7C%7Cpc%7CC5%7Cpc%7CCT%7Cpc%7CCA%7Cpc%7CC6%7Cpg%7C%7Cpc%7CH7%7Cpc%7CC7%7Cpc%7CST%7Cpc%7CS8%7Cpg%7C%7Cpc%7CH6%7Cpc%7CC9%7Cpc%7CC8%7Cpc%7CS9%7Cpg%7C%7Cpc%7CCQ%7Cpc%7CCJ%7Cpc%7CCK%7Cpc%7CSQ%7Cpg%7C%7Cpg%7C%7C'
 ```
 [The Created URL](https://www.bridgebase.com/tools/handviewer.html?lin=pn%7CPrinceBen%2CForrest_%2Csmalark%2Cgranola357%7Cst%7C%7Cmd%7C1SQ982HQ82DKQ763CT%2CSJ643HKJ7653DCAQ4%2CSK5HADAJT52CJ9762%2CSAT7HT94D984CK853%7Csv%7Cn%7Cmb%7Cp%7Cmb%7C1H%7Cmb%7C2N%7Can%7CUnusual+No+Trump%3A+2+5card+minors%7Cmb%7Cp%7Cmb%7C3N%7Cmb%7Cp%7Cmb%7Cp%7Cmb%7Cp%7Cpg%7C%7Cpc%7CH4%7Cpc%7CH2%7Cpc%7CHJ%7Cpc%7CHA%7Cpg%7C%7Cpc%7CDA%7Cpc%7CD4%7Cpc%7CD3%7Cpc%7CS3%7Cpg%7C%7Cpc%7CDJ%7Cpc%7CD8%7Cpc%7CD6%7Cpc%7CS4%7Cpg%7C%7Cpc%7CDT%7Cpc%7CD9%7Cpc%7CD7%7Cpc%7CS6%7Cpg%7C%7Cpc%7CD2%7Cpc%7CC3%7Cpc%7CDK%7Cpc%7CSJ%7Cpg%7C%7Cpc%7CDQ%7Cpc%7CC4%7Cpc%7CD5%7Cpc%7CS7%7Cpg%7C%7Cpc%7CS2%7Cpc%7CH3%7Cpc%7CSK%7Cpc%7CSA%7Cpg%7C%7Cpc%7CHT%7Cpc%7CHQ%7Cpc%7CHK%7Cpc%7CC2%7Cpg%7C%7Cpc%7CH5%7Cpc%7CS5%7Cpc%7CH9%7Cpc%7CH8%7Cpg%7C%7Cpc%7CC5%7Cpc%7CCT%7Cpc%7CCA%7Cpc%7CC6%7Cpg%7C%7Cpc%7CH7%7Cpc%7CC7%7Cpc%7CST%7Cpc%7CS8%7Cpg%7C%7Cpc%7CH6%7Cpc%7CC9%7Cpc%7CC8%7Cpc%7CS9%7Cpg%7C%7Cpc%7CCQ%7Cpc%7CCJ%7Cpc%7CCK%7Cpc%7CSQ%7Cpg%7C%7Cpg%7C%7C)
@@ -143,10 +138,10 @@ pn|PrinceBen,Forrest_,smalark,granola357|st||md|1SQ982HQ82DKQ763CT,SJ643HKJ7653D
 Dump bridgebots DealRecord to JSON
 ```pycon
 >>> lin_path = Path("bridgebots/tests/resources/sample.lin")
->>> results = lin.parse_single(lin_path)
->>> deal_record_schema = schemas.DealRecordSchema(many=True)
+>>> results = bridgebots.parse_single_lin(lin_path)
+>>> deal_record_schema = DealRecordSchema(many=True)
 >>> deal_record_schema.dumps(results)
-'[{"deal": {"dealer": "S", "ns_vulnerable": true, "ew_vulnerable": false, "hands": {"S": ["SQ", "S9", "S8", "S2", "HQ", "H8", "H2", "DK", "DQ", "D7", "D6", "D3", "CT"], "W": ["SJ", "S6", "S4", "S3", "HK", "HJ", "H7", "H6", "H5", "H3", "CA", "CQ", "C4"], "N": ["SK", "S5", "HA", "DA", "DJ", "DT", "D5", "D2", "CJ", "C9", "C7", "C6", "C2"], "E": ["SA", "ST", "S7", "HT", "H9", "H4", "D9", "D8", "D4", "CK", "C8", "C5", "C3"]}}, "board_records": [{"bidding_record": ["PASS", "1H", "2NT", "PASS", "3NT", "PASS", "PASS", "PASS"], "raw_bidding_record": ["p", "1H", "2N", "p", "3N", "p", "p", "p"], "play_record": ["H4", "H2", "HJ", "HA", "DA", "D4", "D3", "S3", "DJ", "D8", "D6", "S4", "DT", "D9", "D7", "S6", "D2", "C3", "DK", "SJ", "DQ", "C4", "D5", "S7", "S2", "H3", "SK", "SA", "HT", "HQ", "HK", "C2", "H5", "S5", "H9", "H8", "C5", "CT", "CA", "C6", "H7", "C7", "ST", "S8", "H6", "C9", "C8", "S9", "CQ", "CJ", "CK", "SQ"], "declarer": "N", "contract": "3NT", "tricks": 6, "scoring": null, "names": {"S": "PrinceBen", "W": "Forrest_", "N": "smalark", "E": "granola357"}, "date": null, "event": null, "bidding_metadata": [{"bid_index": 2, "bid": "2NT", "alerted": false, "explanation": "Unusual No Trump: 2 5card minors"}], "commentary": null}]}]'
+'[{"deal": {"dealer": "S", "ns_vulnerable": true, "ew_vulnerable": false, "hands": {"S": ["SQ", "S9", "S8", "S2", "HQ", "H8", "H2", "DK", "DQ", "D7", "D6", "D3", "CT"], "W": ["SJ", "S6", "S4", "S3", "HK", "HJ", "H7", "H6", "H5", "H3", "CA", "CQ", "C4"], "N": ["SK", "S5", "HA", "DA", "DJ", "DT", "D5", "D2", "CJ", "C9", "C7", "C6", "C2"], "E": ["SA", "ST", "S7", "HT", "H9", "H4", "D9", "D8", "D4", "CK", "C8", "C5", "C3"]}}, "board_records": [{"bidding_record": ["PASS", "1H", "2NT", "PASS", "3NT", "PASS", "PASS", "PASS"], "raw_bidding_record": ["p", "1H", "2N", "p", "3N", "p", "p", "p"], "play_record": ["H4", "H2", "HJ", "HA", "DA", "D4", "D3", "S3", "DJ", "D8", "D6", "S4", "DT", "D9", "D7", "S6", "D2", "C3", "DK", "SJ", "DQ", "C4", "D5", "S7", "S2", "H3", "SK", "SA", "HT", "HQ", "HK", "C2", "H5", "S5", "H9", "H8", "C5", "CT", "CA", "C6", "H7", "C7", "ST", "S8", "H6", "C9", "C8", "S9", "CQ", "CJ", "CK", "SQ"], "declarer": "N", "contract": "3N", "tricks": 6, "score": -300, "scoring": null, "names": {"S": "PrinceBen", "W": "Forrest_", "N": "smalark", "E": "granola357"}, "date": null, "event": null, "bidding_metadata": [{"bid_index": 2, "bid": "2NT", "alerted": false, "explanation": "Unusual No Trump: 2 5card minors"}], "commentary": null}]}]'
 ```
 
 Parse a bridgebots JSON record

--- a/bridgebots/README.md
+++ b/bridgebots/README.md
@@ -48,19 +48,19 @@ from typing import List
 Construct a deal manually
 ```pycon
 >>> hands = {
-    Direction.NORTH: PlayerHand.from_string_lists(
-        ["9", "8", "6", "4"], ["K", "Q", "7", "6", "3"], ["A", "K"], ["7", "3"]
-    ),
-    Direction.SOUTH: PlayerHand.from_string_lists(
-        ["A", "K", "Q", "5"], ["A", "9", "4"], ["J", "5", "2"], ["K", "8", "4"]
-    ),
-    Direction.EAST: PlayerHand.from_string_lists(
-        ["2"], ["J", "10", "8", "5", "2"], ["Q", "8", "7", "4", "3"], ["A", "10"]
-    ),
-    Direction.WEST: PlayerHand.from_string_lists(
-        ["J", "10", "7", "3"], [], ["10", "9", "6"], ["Q", "J", "9", "6", "5", "2"]
-    ),
-}
+        Direction.NORTH: PlayerHand.from_string_lists(
+            ["7", "3"], ["A", "K"], ["K", "Q", "7", "6", "3"], ["9", "8", "6", "4"]
+        ),
+        Direction.SOUTH: PlayerHand.from_string_lists(
+            ["K", "8", "4"], ["J", "5", "2"], ["A", "9", "4"], ["A", "K", "Q", "5"]
+        ),
+        Direction.EAST: PlayerHand.from_string_lists(
+            ["A", "10"], ["Q", "8", "7", "4", "3"], ["J", "10", "8", "5", "2"], ["2"]
+        ),
+        Direction.WEST: PlayerHand.from_string_lists(
+            ["Q", "J", "9", "6", "5", "2"], ["10", "9", "6"], [], ["J", "10", "7", "3"]
+        ),
+    }
 >>> deal = Deal(dealer=Direction.EAST, ns_vulnerable=True, ew_vulnerable=False, hands=hands)
 ```
 

--- a/bridgebots/bridgebots/__init__.py
+++ b/bridgebots/bridgebots/__init__.py
@@ -11,7 +11,6 @@ from .schemas import (
     BidMetadataSchema,
     BoardRecordSchema,
     CommentarySchema,
-    ContractSchema,
     DealRecordSchema,
     DealSchema,
 )

--- a/bridgebots/bridgebots/__init__.py
+++ b/bridgebots/bridgebots/__init__.py
@@ -1,10 +1,17 @@
 from .bids import canonicalize_bid
+from .board_record import BidMetadata, BoardRecord, Commentary, Contract, DealRecord
 from .deal import Card, Deal, PlayerHand
 from .deal_enums import BiddingSuit, Direction, Rank, Suit
 from .deal_utils import deserialize, from_acbl_dict, from_lin_deal, from_pbn_deal, serialize
 from .double_dummy import DoubleDummyScore
 from .lin import build_lin_str, build_lin_url, parse_multi, parse_single
 from .pbn import parse_pbn
-from .play_utils import trick_evaluator, calculate_score
-from .schemas import BidMetadataSchema, BoardRecordSchema, CommentarySchema, DealRecordSchema, DealSchema
-from .board_record import BidMetadata, Commentary, Contract, BoardRecord, DealRecord
+from .play_utils import calculate_score, trick_evaluator
+from .schemas import (
+    BidMetadataSchema,
+    BoardRecordSchema,
+    CommentarySchema,
+    ContractSchema,
+    DealRecordSchema,
+    DealSchema,
+)

--- a/bridgebots/bridgebots/__init__.py
+++ b/bridgebots/bridgebots/__init__.py
@@ -2,9 +2,9 @@ from .bids import canonicalize_bid
 from .board_record import BidMetadata, BoardRecord, Commentary, Contract, DealRecord
 from .deal import Card, Deal, PlayerHand
 from .deal_enums import BiddingSuit, Direction, Rank, Suit
-from .deal_utils import deserialize, from_acbl_dict, from_lin_deal, from_pbn_deal, serialize
+from .deal_utils import deserialize_deal, from_acbl_dict, from_lin_deal, from_pbn_deal, serialize_deal
 from .double_dummy import DoubleDummyScore
-from .lin import build_lin_str, build_lin_url, parse_multi, parse_single
+from .lin import build_lin_str, build_lin_url, parse_multi_lin, parse_single_lin
 from .pbn import parse_pbn
 from .play_utils import calculate_score, trick_evaluator
 from .schemas import (

--- a/bridgebots/bridgebots/__init__.py
+++ b/bridgebots/bridgebots/__init__.py
@@ -1,0 +1,10 @@
+from .bids import canonicalize_bid
+from .deal import Card, Deal, PlayerHand
+from .deal_enums import BiddingSuit, Direction, Rank, Suit
+from .deal_utils import deserialize, from_acbl_dict, from_lin_deal, from_pbn_deal, serialize
+from .double_dummy import DoubleDummyScore
+from .lin import build_lin_str, build_lin_url, parse_multi, parse_single
+from .pbn import parse_pbn
+from .play_utils import trick_evaluator, calculate_score
+from .schemas import BidMetadataSchema, BoardRecordSchema, CommentarySchema, DealRecordSchema, DealSchema
+from .board_record import BidMetadata, Commentary, Contract, BoardRecord, DealRecord

--- a/bridgebots/bridgebots/board_record.py
+++ b/bridgebots/bridgebots/board_record.py
@@ -1,35 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
 from typing import Dict, List, Optional
 
 from bridgebots.deal import Card, Deal
-from bridgebots.deal_enums import Direction
+from bridgebots.deal_enums import BiddingSuit, Direction
+from bridgebots.play_utils import calculate_score
 
 
+@dataclass
 class BidMetadata:
     """
     Represents the alert status and the explanation of a bid
     """
 
-    def __init__(self, bid_index: int, bid: str, alerted: bool = False, explanation: str = None):
-        self.bid_index = bid_index
-        self.bid = bid
-        self.alerted = alerted
-        self.explanation = explanation
-
-    def __repr__(self) -> str:
-        return (
-            f"BidMetadata(bid_index={self.bid_index}, bid={self.bid}, alerted={self.alerted}, "
-            f"explanation={self.explanation})"
-        )
-
-    def __eq__(self, other) -> bool:
-        return (
-            self.bid_index == other.bid_index
-            and self.bid == other.bid
-            and self.alerted == other.alerted
-            and self.explanation == other.explanation
-        )
+    bid_index: int
+    bid: str
+    alerted: bool = False
+    explanation: Optional[str] = None
 
 
+@dataclass
 class Commentary:
     """
     Analyst commentary on the board, bidding, or play.
@@ -38,96 +29,64 @@ class Commentary:
     Commentary after the play will have a play_index of the last card played in the hand
     """
 
-    def __init__(self, bid_index: Optional[int], play_index: Optional[int], comment):
-        assert (bid_index is None) != (play_index is None)  # One of the two must be None
-        self.bid_index = bid_index
-        self.play_index = play_index
-        self.comment = comment
-
-    def __repr__(self) -> str:
-        return f"Commentary(bid_index={self.bid_index}, play_index={self.play_index}, comment={self.comment})"
-
-    def __eq__(self, other) -> bool:
-        return (
-            self.bid_index == other.bid_index and self.play_index == other.play_index and self.comment == other.comment
-        )
+    bid_index: Optional[int]
+    play_index: Optional[int]
+    comment: str
 
 
+@dataclass
+class Contract:
+    level: int
+    suit: Optional[BiddingSuit]
+    doubled: int
+
+    @staticmethod
+    def from_str(contract: str) -> Contract:
+        if contract == "PASS":
+            return Contract(0, None, 0)
+        doubled = contract.count("X")
+        if doubled > 0:
+            contract = contract.replace("X", "")
+        level = int(contract[0])
+        suit = BiddingSuit.from_str(contract[1:])
+        return Contract(level, suit, doubled)
+
+
+@dataclass
 class BoardRecord:
     """
     The record of a played deal.
     """
 
-    def __init__(
-        self,
-        bidding_record: List[str],
-        raw_bidding_record: List[str],
-        play_record: List[Card],
-        declarer: Direction,
-        contract: str,
-        tricks: int,
-        scoring: str = None,
-        names: Dict[Direction, str] = None,
-        date: str = None,
-        event: str = None,
-        bidding_metadata: List[BidMetadata] = None,
-        commentary: List[Commentary] = None,
-    ):
-        self.bidding_record = bidding_record
-        self.raw_bidding_record = raw_bidding_record
-        self.play_record = play_record
-        self.declarer = declarer
-        self.contract = contract
-        self.tricks = tricks
-        self.scoring = scoring
-        self.names = names
-        self.date = date
-        self.event = event
-        self.bidding_metadata = [] if bidding_metadata is None else bidding_metadata
-        self.commentary = [] if commentary is None else commentary
+    bidding_record: List[str]
+    raw_bidding_record: List[str]
+    play_record: List[Card]
+    declarer: Direction
+    contract: Contract
+    tricks: int
+    scoring: Optional[str]
+    names: Optional[Dict[Direction, str]]
+    date: Optional[str]
+    event: Optional[str]
+    bidding_metadata: Optional[List[BidMetadata]]
+    commentary: Optional[List[Commentary]]
+    declarer_vulnerable: InitVar[bool] = None
+    score: int = None
 
-    def __repr__(self) -> str:
-        return (
-            f"BoardRecord(\n"
-            f"\tbidding_record={self.bidding_record},\n"
-            f"\traw_bidding_record={self.raw_bidding_record},\n"
-            f"\tplay_record={self.play_record},\n"
-            f"\tdeclarer={self.declarer}, contract={self.contract}, tricks={self.tricks}, scoring={self.scoring},\n"
-            f"\tnames={self.names},\n"
-            f"\tdate={self.date}, event={self.event},\n"
-            f"\tbidding_metadata={self.bidding_metadata},\n"
-            f"\tcommentary={self.commentary})\n"
-            f")"
-        )
-
-    def __eq__(self, other) -> bool:
-        return (
-            self.bidding_record == other.bidding_record
-            and self.raw_bidding_record == other.raw_bidding_record
-            and self.play_record == other.play_record
-            and self.declarer == other.declarer
-            and self.contract == other.contract
-            and self.tricks == other.tricks
-            and self.scoring == other.scoring
-            and self.names == other.names
-            and self.date == other.date
-            and self.event == other.event
-            and self.bidding_metadata == other.bidding_metadata
-            and self.commentary == other.commentary
-        )
+    def __post_init__(self, declarer_vulnerable: bool):
+        if self.score is None and declarer_vulnerable is None:
+            raise ValueError("score and declarer_vulnerable may not both be None")
+        if self.score is None:
+            self.score = calculate_score(
+                self.contract.level, self.contract.suit, self.contract.doubled, self.tricks, declarer_vulnerable
+            )
 
 
+@dataclass
 class DealRecord:
     """
     Wrapper class for a deal and all the board records associated with the deal
     """
 
-    def __init__(self, deal: Deal, board_records: List[BoardRecord]):
-        self.deal = deal
-        self.board_records = board_records
-
-    def __repr__(self) -> str:
-        return f"DealRecord(\n" f"deal={self.deal},\n" f"board_records={self.board_records}\n" f")"
-
-    def __eq__(self, other) -> bool:
-        return self.deal == other.deal and self.board_records == other.board_records
+    deal: Deal
+    board_records: List[BoardRecord]

--- a/bridgebots/bridgebots/board_record.py
+++ b/bridgebots/bridgebots/board_record.py
@@ -51,6 +51,15 @@ class Contract:
         suit = BiddingSuit.from_str(contract[1:])
         return Contract(level, suit, doubled)
 
+    def __str__(self):
+        if self.level == 0:
+            return "PASS"
+        contract_str = str(self.level) + self.suit.abbreviation()
+        for i in range(self.doubled):
+            contract_str += "X"
+        return contract_str
+
+
 
 @dataclass
 class BoardRecord:

--- a/bridgebots/bridgebots/deal.py
+++ b/bridgebots/bridgebots/deal.py
@@ -128,6 +128,11 @@ class Deal:
         return hash((self.dealer, self.ns_vulnerable, self.ew_vulnerable, frozenset(card_sets)))
 
     @staticmethod
-    def from_cards(dealer: Direction, ns_vulnerable: bool, ew_vulnerable: bool, player_cards: Dict[Direction, List[Card]]) -> Deal:
-        hands = {direction: PlayerHand.from_cards(cards) for direction,cards in player_cards.items()}
+    def from_cards(
+        dealer: Direction, ns_vulnerable: bool, ew_vulnerable: bool, player_cards: Dict[Direction, List[Card]]
+    ) -> Deal:
+        hands = {direction: PlayerHand.from_cards(cards) for direction, cards in player_cards.items()}
         return Deal(dealer, ns_vulnerable, ew_vulnerable, hands)
+
+    def is_vulnerable(self, direction: Direction):
+        return self.ns_vulnerable if direction in [Direction.NORTH, Direction.SOUTH] else self.ew_vulnerable

--- a/bridgebots/bridgebots/deal.py
+++ b/bridgebots/bridgebots/deal.py
@@ -54,17 +54,17 @@ class PlayerHand:
                 self.cards.append(Card(suit, rank))
 
     @staticmethod
-    def from_string_lists(clubs: List[str], diamonds: List[str], hearts: List[str], spades: List[str]) -> PlayerHand:
+    def from_string_lists(spades: List[str], hearts: List[str], diamonds: List[str], clubs: List[str]) -> PlayerHand:
         """
         Build a PlayerHand out of Lists of Strings which map to Ranks for each suit. e.g. ['A', 'T', '3'] to represent
         a suit holding of Ace, Ten, Three
         :return: PlayerHand representing the holdings provided by the arguments
         """
         suits = {
-            Suit.CLUBS: sorted([Rank.from_str(card_str) for card_str in clubs], reverse=True),
-            Suit.DIAMONDS: sorted([Rank.from_str(card_str) for card_str in diamonds], reverse=True),
-            Suit.HEARTS: sorted([Rank.from_str(card_str) for card_str in hearts], reverse=True),
             Suit.SPADES: sorted([Rank.from_str(card_str) for card_str in spades], reverse=True),
+            Suit.HEARTS: sorted([Rank.from_str(card_str) for card_str in hearts], reverse=True),
+            Suit.DIAMONDS: sorted([Rank.from_str(card_str) for card_str in diamonds], reverse=True),
+            Suit.CLUBS: sorted([Rank.from_str(card_str) for card_str in clubs], reverse=True),
         }
         return PlayerHand(suits)
 

--- a/bridgebots/bridgebots/deal_enums.py
+++ b/bridgebots/bridgebots/deal_enums.py
@@ -82,9 +82,14 @@ class BiddingSuit(Enum):
     def to_suit(self) -> Suit:
         return self.value[1]
 
+    def abbreviation(self) -> str:
+        return self.name[0]
+
     @classmethod
     def from_str(cls, bidding_suit_str: str) -> BiddingSuit:
         return BiddingSuit(cls.__from_str_map__[bidding_suit_str.upper()])
+
+
 
 
 @total_ordering
@@ -132,3 +137,4 @@ class Rank(Enum):
 
     def abbreviation(self) -> str:
         return self.value[1]
+

--- a/bridgebots/bridgebots/deal_enums.py
+++ b/bridgebots/bridgebots/deal_enums.py
@@ -90,8 +90,6 @@ class BiddingSuit(Enum):
         return BiddingSuit(cls.__from_str_map__[bidding_suit_str.upper()])
 
 
-
-
 @total_ordering
 class Rank(Enum):
     TWO = 2, "2"
@@ -137,4 +135,3 @@ class Rank(Enum):
 
     def abbreviation(self) -> str:
         return self.value[1]
-

--- a/bridgebots/bridgebots/deal_utils.py
+++ b/bridgebots/bridgebots/deal_utils.py
@@ -79,6 +79,7 @@ def from_acbl_dict(acbl_dict: Dict[str, str]) -> Deal:
         suit_string_lists = [
             [] if acbl_dict[suit_key] == "-----" else acbl_dict[suit_key].split() for suit_key in suit_keys
         ]
+        suit_string_lists.reverse()
         player_cards[direction] = PlayerHand.from_string_lists(*suit_string_lists)
 
     dealer_direction = Direction[acbl_dict["dealer"].upper()]
@@ -106,9 +107,7 @@ def from_pbn_deal(dealer_str: str, vulnerability_str: str, deal_str: str) -> Dea
     deal_str = deal_str[2:]
     player_hands = {}
     for player_str in deal_str.split():
-        suits = player_str.split(".")
-        suits.reverse()
-        suit_lists = [list(suit) for suit in suits]
+        suit_lists = [list(suit) for suit in player_str.split(".")]
         player_hands[hands_direction] = PlayerHand.from_string_lists(*suit_lists)
         hands_direction = hands_direction.next()
 
@@ -130,7 +129,6 @@ def from_lin_deal(lin_dealer_str: str, vulnerability_str: str, holdings_str: str
     player_hands = {}
     current_direction = Direction.SOUTH
     for suit_holdings in players_suit_holdings:
-        suit_holdings.reverse()
         suit_holdings_lists = [list(suit_holding) for suit_holding in suit_holdings]
         player_hands[current_direction] = PlayerHand.from_string_lists(*suit_holdings_lists)
         current_direction = current_direction.next()

--- a/bridgebots/bridgebots/deal_utils.py
+++ b/bridgebots/bridgebots/deal_utils.py
@@ -16,7 +16,7 @@ _SUIT_CHAR_REGEX = re.compile("[SHDC]")
 _DECK_SET = frozenset({Card(suit, rank) for rank in Rank for suit in Suit})
 
 
-def serialize(deal: Deal) -> bytes:
+def serialize_deal(deal: Deal) -> bytes:
     """
     Convert a Deal to a binary representation. Use two bits for each card to represent the Direction which holds that
     card. Two more bits encode the Direction that delt, and two final bits to encode vulnerability.
@@ -40,7 +40,7 @@ def serialize(deal: Deal) -> bytes:
     return binary_deal.to_bytes(14, byteorder="big")
 
 
-def deserialize(binary_deal_bytes: bytes) -> Deal:
+def deserialize_deal(binary_deal_bytes: bytes) -> Deal:
     """
     Unpack compressed deal data into a Deal object
     :param binary_deal_bytes: compressed byte representation of a deal

--- a/bridgebots/bridgebots/double_dummy.py
+++ b/bridgebots/bridgebots/double_dummy.py
@@ -70,6 +70,7 @@ class DoubleDummyScore:
         return scores
 
 
+# TODO remove in favor of DealRecord
 class DoubleDummyDeal:
     """
     Wrapper class which holds a deal and its double dummy scores

--- a/bridgebots/bridgebots/lin.py
+++ b/bridgebots/bridgebots/lin.py
@@ -69,6 +69,7 @@ def _parse_bidding_record(raw_bidding_record: List[str], lin_dict: Dict) -> Tupl
 
     contract = bidding_record[-4]
     if contract in ["X", "XX"]:
+        # Loop backwards until we find the first contractual bid
         for i in range(len(bidding_record) - 5, 0, -1):
             if bidding_record[i] not in ["X", "PASS"]:
                 contract = bidding_record[i] + contract

--- a/bridgebots/bridgebots/lin.py
+++ b/bridgebots/bridgebots/lin.py
@@ -206,7 +206,7 @@ def _build_play_str(board_record: BoardRecord) -> str:
     return play_str
 
 
-def parse_single(file_path: Path) -> List[DealRecord]:
+def parse_single_lin(file_path: Path) -> List[DealRecord]:
     """
     Parse a board-per-line LIN file
     :param file_path: path to single-board LIN file
@@ -223,7 +223,7 @@ def parse_single(file_path: Path) -> List[DealRecord]:
         return [DealRecord(deal, board_records) for deal, board_records in records.items()]
 
 
-def parse_multi(file_path: Path) -> List[DealRecord]:
+def parse_multi_lin(file_path: Path) -> List[DealRecord]:
     """
     Parse a multi-board session LIN file
     :param file_path: path to multi-board LIN file

--- a/bridgebots/bridgebots/lin.py
+++ b/bridgebots/bridgebots/lin.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from bridgebots.bids import canonicalize_bid
-from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, DealRecord
+from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, Contract, DealRecord
 from bridgebots.deal import Card, Deal
 from bridgebots.deal_enums import BiddingSuit, Direction, Suit
 from bridgebots.deal_utils import from_lin_deal
@@ -50,7 +50,7 @@ def _parse_deal(lin_dict: dict) -> Deal:
     return from_lin_deal(lin_dealer_str, vulnerability_str, holding_str)
 
 
-def _parse_bidding_record(raw_bidding_record: List[str], lin_dict: Dict) -> Tuple[List[str], List[BidMetadata]]:
+def _parse_bidding_record(raw_bidding_record: List[str], lin_dict: Dict) -> Tuple[List[str], List[BidMetadata], str]:
     """
     Convert LIN bids to their bridgebots representation. Create BiddingMetadata to capture alerts and bid explanations.
     :return: A pair of the parsed bidding record and the list of BiddingMetadata associated with the auction
@@ -66,7 +66,14 @@ def _parse_bidding_record(raw_bidding_record: List[str], lin_dict: Dict) -> Tupl
         alerted = "!" in bid
         if alerted or bid_index in bid_announcements:
             bidding_metadata.append(BidMetadata(bid_index, canonical_bid, alerted, bid_announcements.get(bid_index)))
-    return bidding_record, bidding_metadata
+
+    contract = bidding_record[-4]
+    if contract in ["X", "XX"]:
+        for i in range(len(bidding_record) - 5, 0, -1):
+            if bidding_record[i] not in ["X", "PASS"]:
+                contract = bidding_record[i] + contract
+                break
+    return bidding_record, bidding_metadata, contract
 
 
 def _determine_declarer(play_record: List[Card], bidding_record: List[str], deal: Deal) -> Direction:
@@ -138,8 +145,7 @@ def _parse_board_record(lin_dict: Dict, deal: Deal) -> BoardRecord:
     """
     player_names = _parse_player_names(lin_dict)
     raw_bidding_record = lin_dict["mb"]
-    bidding_record, bidding_metadata = _parse_bidding_record(raw_bidding_record, lin_dict)
-    contract = bidding_record[-4]  # Last bid before pass out
+    bidding_record, bidding_metadata, contract = _parse_bidding_record(raw_bidding_record, lin_dict)
     play_record = [Card.from_str(cs) for cs in lin_dict["pc"]]
     declarer = _determine_declarer(play_record, bidding_record, deal)
     tricks = _parse_tricks(lin_dict, declarer, contract, play_record)
@@ -149,7 +155,8 @@ def _parse_board_record(lin_dict: Dict, deal: Deal) -> BoardRecord:
         raw_bidding_record=raw_bidding_record,
         play_record=play_record,
         declarer=declarer,
-        contract=contract,
+        contract=Contract.from_str(contract),
+        declarer_vulnerable=deal.is_vulnerable(declarer),
         tricks=tricks,
         scoring=None,
         names=player_names,

--- a/bridgebots/bridgebots/pbn.py
+++ b/bridgebots/bridgebots/pbn.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import re
 from collections import defaultdict
@@ -110,7 +111,7 @@ def _update_bidding_metadata(
         bid_metadata = BidMetadata(bid_index=bid_index - 1, bid=bidding_record[-1])
         bidding_metadata.append(bid_metadata)
     if raw_bid == "!":
-        bid_metadata.alerted = True
+        bid_metadata = dataclasses.replace(bid_metadata, alerted=True)
     else:
         # Attempt to determine which note should be used as an explanation
         match = re.match("=([0-9]+)=", raw_bid)
@@ -120,9 +121,10 @@ def _update_bidding_metadata(
         else:
             explanation = raw_bid
         if bid_metadata.explanation:
-            bid_metadata.explanation += " | " + explanation
+            bid_metadata = dataclasses.replace(bid_metadata, explanation=bid_metadata.explanation + " | " + explanation)
         else:
-            bid_metadata.explanation = explanation
+            bid_metadata = dataclasses.replace(bid_metadata, explanation=explanation)
+    bidding_metadata[-1] = bid_metadata
 
 
 def _parse_bidding_record(raw_bidding_record: List[str], record_dict: dict) -> Tuple[List[str], List[BidMetadata]]:
@@ -218,8 +220,17 @@ def _parse_board_record(record_dict: Dict, deal: Deal) -> BoardRecord:
     bidding_record, bidding_metadata = _parse_bidding_record(raw_bidding_record, record_dict)
     play_record_strings = record_dict.get("play_record") or []
     play_record = _sort_play_record(play_record_strings, record_dict["Contract"])
-    result_str = record_dict.get("Result")
-    result = int(result_str) if result_str and result_str != "" else None
+
+    if not (result_str := record_dict.get("Result")):
+        message = f"Missing tricks result: {result_str}"
+        logging.warning(message)
+        raise ValueError(message)
+
+    if not (contract_str := record_dict.get("Contract")):
+        message = f"Missing contract: {contract_str}"
+        logging.warning(message)
+        raise ValueError(message)
+
     player_names = {
         Direction.NORTH: record_dict.get("North"),
         Direction.SOUTH: record_dict.get("South"),
@@ -232,9 +243,9 @@ def _parse_board_record(record_dict: Dict, deal: Deal) -> BoardRecord:
         raw_bidding_record=raw_bidding_record,
         play_record=play_record,
         declarer=declarer,
-        contract=Contract.from_str(record_dict["Contract"]),
+        contract=Contract.from_str(contract_str),
         declarer_vulnerable=deal.is_vulnerable(declarer),
-        tricks=result,
+        tricks=int(result_str),
         scoring=record_dict.get("Scoring"),
         names=player_names,
         date=record_dict.get("Date"),

--- a/bridgebots/bridgebots/pbn.py
+++ b/bridgebots/bridgebots/pbn.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from bridgebots.bids import canonicalize_bid
-from bridgebots.board_record import BidMetadata, BoardRecord, DealRecord
+from bridgebots.board_record import BidMetadata, BoardRecord, Contract, DealRecord
 from bridgebots.deal import Card, Deal
 from bridgebots.deal_enums import BiddingSuit, Direction
 from bridgebots.deal_utils import from_pbn_deal
@@ -206,7 +206,7 @@ def _sort_play_record(trick_records: List[List[str]], contract: str) -> List[Car
         return []
 
 
-def _parse_board_record(record_dict: Dict) -> BoardRecord:
+def _parse_board_record(record_dict: Dict, deal: Deal) -> BoardRecord:
     """
     Convert the record dictionary to a BoardRecord
     :param record_dict: mapping of PBN keys to deal or board information
@@ -232,7 +232,8 @@ def _parse_board_record(record_dict: Dict) -> BoardRecord:
         raw_bidding_record=raw_bidding_record,
         play_record=play_record,
         declarer=declarer,
-        contract=record_dict["Contract"],
+        contract=Contract.from_str(record_dict["Contract"]),
+        declarer_vulnerable=deal.is_vulnerable(declarer),
         tricks=result,
         scoring=record_dict.get("Scoring"),
         names=player_names,
@@ -251,7 +252,7 @@ def _parse_single_pbn_record(record_strings: List[str]) -> Tuple[Deal, BoardReco
     """
     record_dict = _build_record_dict(record_strings)
     deal = from_pbn_deal(record_dict["Dealer"], record_dict["Vulnerable"], record_dict["Deal"])
-    board_record = _parse_board_record(record_dict)
+    board_record = _parse_board_record(record_dict, deal)
     return deal, board_record
 
 

--- a/bridgebots/bridgebots/play_utils.py
+++ b/bridgebots/bridgebots/play_utils.py
@@ -42,7 +42,7 @@ _TRICK_VALUE = {
 }
 
 
-def calculate_bonus(
+def _calculate_bonus(
     level: int, suit: BiddingSuit, doubled: int, vulnerable: bool, contracted_trick_score: int, overtricks: int
 ) -> int:
     score = 0
@@ -113,11 +113,11 @@ def calculate_score(level: int, suit: Optional[BiddingSuit], doubled: int, trick
     if scoring_tricks >= level:
         double_multiplier = pow(2, doubled)
         first_trick_score = _FIRST_TRICK_VALUE[suit] * double_multiplier
-        contracted_tricks_score = _TRICK_VALUE[suit] * double_multiplier * (level - 1)
-        bonus = calculate_bonus(
-            level, suit, doubled, vulnerable, first_trick_score + contracted_tricks_score, scoring_tricks - level
+        subsequent_tricks_score = _TRICK_VALUE[suit] * double_multiplier * (level - 1)
+        bonus = _calculate_bonus(
+            level, suit, doubled, vulnerable, first_trick_score + subsequent_tricks_score, scoring_tricks - level
         )
-        return first_trick_score + contracted_tricks_score + bonus
+        return first_trick_score + subsequent_tricks_score + bonus
     else:
         undertricks = level + 6 - tricks
         score_key = (vulnerable, doubled)

--- a/bridgebots/bridgebots/play_utils.py
+++ b/bridgebots/bridgebots/play_utils.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable
+from typing import Callable, Optional
 
 from bridgebots.deal import Card
 from bridgebots.deal_enums import BiddingSuit, Suit
@@ -24,3 +24,111 @@ def trick_evaluator(trump_suit: BiddingSuit, suit_led: Suit) -> Callable:
     progress
     """
     return partial(_evaluate_card, trump_suit, suit_led)
+
+
+_FIRST_TRICK_VALUE = {
+    BiddingSuit.NO_TRUMP: 40,
+    BiddingSuit.SPADES: 30,
+    BiddingSuit.HEARTS: 30,
+    BiddingSuit.DIAMONDS: 20,
+    BiddingSuit.CLUBS: 20,
+}
+_TRICK_VALUE = {
+    BiddingSuit.NO_TRUMP: 30,
+    BiddingSuit.SPADES: 30,
+    BiddingSuit.HEARTS: 30,
+    BiddingSuit.DIAMONDS: 20,
+    BiddingSuit.CLUBS: 20,
+}
+
+
+def calculate_bonus(
+    level: int, suit: BiddingSuit, doubled: int, vulnerable: bool, contracted_trick_score: int, overtricks: int
+) -> int:
+    score = 0
+    # Slam bonus
+    if level == 7:
+        score += 1500 if vulnerable else 1000
+    elif level == 6:
+        score += 750 if vulnerable else 500
+
+    # Game / part-score
+    if contracted_trick_score >= 100:
+        score += 500 if vulnerable else 300
+    else:
+        score += 50
+
+    # Overtricks
+    if doubled == 0:
+        score += overtricks * _TRICK_VALUE[suit]
+    elif doubled == 1:
+        score += 50
+        score += overtricks * (200 if vulnerable else 100)
+    elif doubled == 2:
+        score += 100
+        score += overtricks * (400 if vulnerable else 200)
+    return score
+
+
+_FIRST_UNDERTRICK_VALUE = {
+    (False, 0): 50,
+    (False, 1): 100,
+    (False, 2): 200,
+    (True, 0): 100,
+    (True, 1): 200,
+    (True, 2): 400,
+}
+
+_SECOND_THIRD_UNDERTRICK_VALUE = {
+    (False, 0): 50,
+    (False, 1): 200,
+    (False, 2): 400,
+    (True, 0): 100,
+    (True, 1): 300,
+    (True, 2): 600,
+}
+
+_SUBSEQUENT_UNDERTRICK_VALUE = {
+    (False, 0): 50,
+    (False, 1): 300,
+    (False, 2): 600,
+    (True, 0): 100,
+    (True, 1): 300,
+    (True, 2): 600,
+}
+
+
+def calculate_score(level: int, suit: Optional[BiddingSuit], doubled: int, tricks: int, vulnerable: bool) -> int:
+    """
+    :param level: contract level (4 in 4S)
+    :param suit: contract bidding suit
+    :param doubled: 0=undoubled, 1=doubled, 2=redoubled
+    :param tricks: tricks taken by declarer
+    :param vulnerable: vulnerability of declarer
+    :return: declarer's score
+    """
+    if level == 0:  # Pass Out
+        return 0
+    scoring_tricks = tricks - 6
+    if scoring_tricks >= level:
+        double_multiplier = pow(2, doubled)
+        first_trick_score = _FIRST_TRICK_VALUE[suit] * double_multiplier
+        contracted_tricks_score = _TRICK_VALUE[suit] * double_multiplier * (level - 1)
+        bonus = calculate_bonus(
+            level, suit, doubled, vulnerable, first_trick_score + contracted_tricks_score, scoring_tricks - level
+        )
+        return first_trick_score + contracted_tricks_score + bonus
+    else:
+        undertricks = level + 6 - tricks
+        score_key = (vulnerable, doubled)
+        score = 0
+        for i in range(0, undertricks):
+            score_dict = (
+                _FIRST_UNDERTRICK_VALUE
+                if i == 0
+                else _SECOND_THIRD_UNDERTRICK_VALUE
+                if 0 < i < 3
+                else _SUBSEQUENT_UNDERTRICK_VALUE
+            )
+            score -= score_dict[score_key]
+        return score

--- a/bridgebots/bridgebots/schemas.py
+++ b/bridgebots/bridgebots/schemas.py
@@ -113,8 +113,8 @@ class BoardRecordSchema(Schema):
     )
     date = fields.Str(missing=None)  # TODO make this datetime?
     event = fields.Str(missing=None)
-    bidding_metadata = fields.List(fields.Nested(BidMetadataSchema), missing=[])
-    commentary = fields.List(fields.Nested(CommentarySchema), missing=[])
+    bidding_metadata = fields.List(fields.Nested(BidMetadataSchema), missing=None)
+    commentary = fields.List(fields.Nested(CommentarySchema), missing=None)
 
     class Meta:
         ordered = True

--- a/bridgebots/pyproject.toml
+++ b/bridgebots/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Forrest Rice <forrest.d.rice@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 marshmallow = "^3.12.1"
 
 [tool.poetry.dev-dependencies]

--- a/bridgebots/pyproject.toml
+++ b/bridgebots/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bridgebots"
-version = "0.0.6"
+version = "0.0.7"
 description = "Data processing for Contract Bridge"
 authors = ["Forrest Rice <forrest.d.rice@gmail.com>"]
 license = "MIT"

--- a/bridgebots/tests/test_deal.py
+++ b/bridgebots/tests/test_deal.py
@@ -5,11 +5,11 @@ from bridgebots import Card, PlayerHand, Rank, Suit
 
 class TestDeal(unittest.TestCase):
     def test_valid_player_hand_cards(self):
-        ph = PlayerHand.from_string_lists(["A", "K", "2"], ["A", "K", "Q"], ["10", "3"], ["J", "9", "8", "3", "2"])
+        ph = PlayerHand.from_string_lists(["J", "9", "8", "3", "2"], ["10", "3"], ["A", "K", "Q"], ["A", "K", "2"])
         self.assertEqual(13, len(ph.cards))
 
     def test_constructor_sorts(self):
-        ph = PlayerHand.from_string_lists(["2", "A", "K"], ["A", "K", "Q"], ["10", "3"], ["J", "9", "8", "3", "2"])
+        ph = PlayerHand.from_string_lists(["J", "9", "8", "3", "2"], ["10", "3"], ["A", "K", "Q"], ["2", "A", "K"])
         self.assertEqual(
             [Card(Suit.SPADES, Rank.JACK), Card(Suit.SPADES, Rank.NINE), Card(Suit.SPADES, Rank.EIGHT)], ph.cards[0:3]
         )

--- a/bridgebots/tests/test_deal.py
+++ b/bridgebots/tests/test_deal.py
@@ -1,7 +1,6 @@
 import unittest
 
-from bridgebots.deal import Card, PlayerHand
-from bridgebots.deal_enums import Rank, Suit
+from bridgebots import Card, PlayerHand, Rank, Suit
 
 
 class TestDeal(unittest.TestCase):

--- a/bridgebots/tests/test_deal_utils.py
+++ b/bridgebots/tests/test_deal_utils.py
@@ -1,10 +1,7 @@
 import json
 import unittest
 
-from bridgebots import deal_utils
-from bridgebots.deal import Deal, PlayerHand
-from bridgebots.deal_enums import Direction, Suit
-from bridgebots.deal_utils import from_acbl_dict
+from bridgebots import Deal, Direction, PlayerHand, Suit, deal_utils, from_acbl_dict
 
 
 class TestAcblDeal(unittest.TestCase):

--- a/bridgebots/tests/test_deal_utils.py
+++ b/bridgebots/tests/test_deal_utils.py
@@ -60,6 +60,6 @@ class TestBinaryDeal(unittest.TestCase):
     test_deal = Deal(Direction.EAST, True, False, hands)
 
     def test_serialize_then_deserialize(self):
-        binary_deal = deal_utils.serialize(TestBinaryDeal.test_deal)
-        out_deal = deal_utils.deserialize(binary_deal)
+        binary_deal = deal_utils.serialize_deal(TestBinaryDeal.test_deal)
+        out_deal = deal_utils.deserialize_deal(binary_deal)
         self.assertEqual(TestBinaryDeal.test_deal, out_deal)

--- a/bridgebots/tests/test_deal_utils.py
+++ b/bridgebots/tests/test_deal_utils.py
@@ -19,7 +19,10 @@ class TestAcblDeal(unittest.TestCase):
         handrecord_json = json.loads(handrecord)
         deal = from_acbl_dict(handrecord_json)
         expected_north = PlayerHand.from_string_lists(
-            ["K", "8", "2"], ["6", "2"], ["A", "Q", "10", "9", "3"], ["10", "6", "2"]
+            ["10", "6", "2"],
+            ["A", "Q", "10", "9", "3"],
+            ["6", "2"],
+            ["K", "8", "2"],
         )
         self.assertEqual(expected_north, deal.hands[Direction.NORTH])
         self.assertTrue(deal.ns_vulnerable)
@@ -45,16 +48,16 @@ class TestAcblDeal(unittest.TestCase):
 class TestBinaryDeal(unittest.TestCase):
     hands = {
         Direction.NORTH: PlayerHand.from_string_lists(
-            ["9", "8", "6", "4"], ["K", "Q", "7", "6", "3"], ["A", "K"], ["7", "3"]
+            ["7", "3"], ["A", "K"], ["K", "Q", "7", "6", "3"], ["9", "8", "6", "4"]
         ),
         Direction.SOUTH: PlayerHand.from_string_lists(
-            ["A", "K", "Q", "5"], ["A", "9", "4"], ["J", "5", "2"], ["K", "8", "4"]
+            ["K", "8", "4"], ["J", "5", "2"], ["A", "9", "4"], ["A", "K", "Q", "5"]
         ),
         Direction.EAST: PlayerHand.from_string_lists(
-            ["2"], ["J", "10", "8", "5", "2"], ["Q", "8", "7", "4", "3"], ["A", "10"]
+            ["A", "10"], ["Q", "8", "7", "4", "3"], ["J", "10", "8", "5", "2"], ["2"]
         ),
         Direction.WEST: PlayerHand.from_string_lists(
-            ["J", "10", "7", "3"], [], ["10", "9", "6"], ["Q", "J", "9", "6", "5", "2"]
+            ["Q", "J", "9", "6", "5", "2"], ["10", "9", "6"], [], ["J", "10", "7", "3"]
         ),
     }
     test_deal = Deal(Direction.EAST, True, False, hands)

--- a/bridgebots/tests/test_double_dummy_score.py
+++ b/bridgebots/tests/test_double_dummy_score.py
@@ -1,7 +1,6 @@
 import unittest
 
-from bridgebots.deal_enums import BiddingSuit, Direction
-from bridgebots.double_dummy import DoubleDummyScore
+from bridgebots import BiddingSuit, Direction, DoubleDummyScore
 
 
 class TestDoubleDummyScore(unittest.TestCase):

--- a/bridgebots/tests/test_lin.py
+++ b/bridgebots/tests/test_lin.py
@@ -13,8 +13,8 @@ from bridgebots import (
     Suit,
     build_lin_str,
     build_lin_url,
-    parse_multi,
-    parse_single,
+    parse_multi_lin,
+    parse_single_lin,
 )
 from bridgebots.lin import (
     _determine_declarer,
@@ -195,7 +195,7 @@ class TestParseLin(unittest.TestCase):
 
     def test_parse_multi(self):
         lin_path = Path(__file__).parent / "resources" / "usbf_sf_14502.lin"
-        deal_records = parse_multi(lin_path)
+        deal_records = parse_multi_lin(lin_path)
         self.assertEqual(15, len(deal_records))
         self.assertEqual(2, len(deal_records[0].board_records))
         self.assertEqual(
@@ -209,7 +209,7 @@ class TestParseLin(unittest.TestCase):
 
 
 class TestBuildLin(unittest.TestCase):
-    deal_records = parse_single(Path(__file__).parent / "resources" / "sample.lin")
+    deal_records = parse_single_lin(Path(__file__).parent / "resources" / "sample.lin")
 
     def test_build_lin_str(self):
         expected_lin_str = (

--- a/bridgebots/tests/test_lin.py
+++ b/bridgebots/tests/test_lin.py
@@ -1,9 +1,9 @@
 import unittest
 from pathlib import Path
 
-from bridgebots.board_record import BidMetadata, BoardRecord, Commentary
+from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, Contract
 from bridgebots.deal import Card
-from bridgebots.deal_enums import Direction, Rank, Suit
+from bridgebots.deal_enums import BiddingSuit, Direction, Rank, Suit
 from bridgebots.lin import (
     _determine_declarer,
     _parse_bidding_record,
@@ -83,7 +83,7 @@ class TestParseLin(unittest.TestCase):
 
     def test_parse_bidding_record(self):
         raw_bidding_record = ["1N", "p", "p", "2C!", "p", "2D!", "d", "p", "p", "p"]
-        bidding_record, bidding_metadata = _parse_bidding_record(
+        bidding_record, bidding_metadata, contract = _parse_bidding_record(
             raw_bidding_record, {"an": [(0, "15-17"), (3, "!d or !h!s")]}
         )
         self.assertEqual(["1NT", "PASS", "PASS", "2C", "PASS", "2D", "X", "PASS", "PASS", "PASS"], bidding_record)
@@ -166,7 +166,8 @@ class TestParseLin(unittest.TestCase):
             raw_bidding_record=["p", "1H", "2N", "p", "3N", "p", "p", "p"],
             play_record=[Card.from_str(c) for c in self.expected_play_record],
             declarer=Direction.NORTH,
-            contract="3NT",
+            contract=Contract.from_str("3NT"),
+            declarer_vulnerable=False,
             tricks=6,
             scoring=None,
             names={
@@ -196,6 +197,7 @@ class TestParseLin(unittest.TestCase):
         self.assertEqual(
             [Rank.QUEEN, Rank.TEN, Rank.FIVE], deal_records[0].deal.hands[Direction.NORTH].suits[Suit.HEARTS]
         )
+        self.assertEqual(Contract(4, BiddingSuit.SPADES, 1), deal_records[7].board_records[0].contract)
 
 
 class TestBuildLin(unittest.TestCase):

--- a/bridgebots/tests/test_lin.py
+++ b/bridgebots/tests/test_lin.py
@@ -1,9 +1,21 @@
 import unittest
 from pathlib import Path
 
-from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, Contract
-from bridgebots.deal import Card
-from bridgebots.deal_enums import BiddingSuit, Direction, Rank, Suit
+from bridgebots import (
+    BidMetadata,
+    BiddingSuit,
+    BoardRecord,
+    Card,
+    Commentary,
+    Contract,
+    Direction,
+    Rank,
+    Suit,
+    build_lin_str,
+    build_lin_url,
+    parse_multi,
+    parse_single,
+)
 from bridgebots.lin import (
     _determine_declarer,
     _parse_bidding_record,
@@ -12,10 +24,6 @@ from bridgebots.lin import (
     _parse_lin_string,
     _parse_player_names,
     _parse_tricks,
-    build_lin_str,
-    build_lin_url,
-    parse_multi,
-    parse_single,
 )
 
 

--- a/bridgebots/tests/test_pbn.py
+++ b/bridgebots/tests/test_pbn.py
@@ -1,8 +1,8 @@
 import unittest
 from pathlib import Path
 
-from bridgebots.board_record import BidMetadata
-from bridgebots.deal_enums import Direction, Rank, Suit
+from bridgebots.board_record import BidMetadata, Contract
+from bridgebots.deal_enums import BiddingSuit, Direction, Rank, Suit
 from bridgebots.pbn import _build_record_dict, _parse_bidding_record, _sort_play_record, parse_pbn
 
 
@@ -91,7 +91,7 @@ class TestParsePbnFile(unittest.TestCase):
             [str(card) for card in board_record_1.play_record],
         )
         self.assertEqual(Direction.WEST, board_record_1.declarer)
-        self.assertEqual("3NT", board_record_1.contract)
+        self.assertEqual(Contract(3, BiddingSuit.NO_TRUMP, 0), board_record_1.contract)
         self.assertEqual(9, board_record_1.tricks)
         self.assertEqual("IMP;Cross", board_record_1.scoring)
         self.assertEqual("2004.05.05", board_record_1.date)

--- a/bridgebots/tests/test_pbn.py
+++ b/bridgebots/tests/test_pbn.py
@@ -1,9 +1,8 @@
 import unittest
 from pathlib import Path
 
-from bridgebots.board_record import BidMetadata, Contract
-from bridgebots.deal_enums import BiddingSuit, Direction, Rank, Suit
-from bridgebots.pbn import _build_record_dict, _parse_bidding_record, _sort_play_record, parse_pbn
+from bridgebots import BidMetadata, BiddingSuit, Contract, Direction, Rank, Suit, parse_pbn
+from bridgebots.pbn import _build_record_dict, _parse_bidding_record, _sort_play_record
 
 
 class TestParsePbnFile(unittest.TestCase):

--- a/bridgebots/tests/test_play_utils.py
+++ b/bridgebots/tests/test_play_utils.py
@@ -1,0 +1,100 @@
+import unittest
+
+from bridgebots import BiddingSuit, calculate_score
+
+
+class TestScoring(unittest.TestCase):
+    def test_passed_hand(self):
+        self.assertEqual(0, calculate_score(0, None, 0, 0, True))
+
+    def test_one_minor(self):
+        # 1C, 1CX, 1CXX making exactly
+        self.assertEqual(70, calculate_score(1, BiddingSuit.CLUBS, 0, 7, True))
+        self.assertEqual(140, calculate_score(1, BiddingSuit.CLUBS, 1, 7, True))
+        self.assertEqual(230, calculate_score(1, BiddingSuit.CLUBS, 2, 7, False))
+
+        # 1C, 1CX, 1CXX making with 4 non-vulnerable overtricks
+        self.assertEqual(150, calculate_score(1, BiddingSuit.CLUBS, 0, 11, False))
+        self.assertEqual(540, calculate_score(1, BiddingSuit.CLUBS, 1, 11, False))
+        self.assertEqual(1030, calculate_score(1, BiddingSuit.CLUBS, 2, 11, False))
+
+        # 1C, 1CX, 1CXX making with 4 vulnerable overtricks
+        self.assertEqual(150, calculate_score(1, BiddingSuit.CLUBS, 0, 11, True))
+        self.assertEqual(940, calculate_score(1, BiddingSuit.CLUBS, 1, 11, True))
+        self.assertEqual(1830, calculate_score(1, BiddingSuit.CLUBS, 2, 11, True))
+
+    def test_three_no_trump(self):
+        # 3N, 3NX, 3NXX making exactly
+        self.assertEqual(400, calculate_score(3, BiddingSuit.NO_TRUMP, 0, 9, False))
+        self.assertEqual(550, calculate_score(3, BiddingSuit.NO_TRUMP, 1, 9, False))
+        self.assertEqual(800, calculate_score(3, BiddingSuit.NO_TRUMP, 2, 9, False))
+        self.assertEqual(600, calculate_score(3, BiddingSuit.NO_TRUMP, 0, 9, True))
+        self.assertEqual(750, calculate_score(3, BiddingSuit.NO_TRUMP, 1, 9, True))
+        self.assertEqual(1000, calculate_score(3, BiddingSuit.NO_TRUMP, 2, 9, True))
+
+        # 3N, 3NX, 3NXX making with two overtricks
+        self.assertEqual(460, calculate_score(3, BiddingSuit.NO_TRUMP, 0, 11, False))
+        self.assertEqual(750, calculate_score(3, BiddingSuit.NO_TRUMP, 1, 11, False))
+        self.assertEqual(1200, calculate_score(3, BiddingSuit.NO_TRUMP, 2, 11, False))
+        self.assertEqual(660, calculate_score(3, BiddingSuit.NO_TRUMP, 0, 11, True))
+        self.assertEqual(1150, calculate_score(3, BiddingSuit.NO_TRUMP, 1, 11, True))
+        self.assertEqual(1800, calculate_score(3, BiddingSuit.NO_TRUMP, 2, 11, True))
+
+    def test_small_major_slam(self):
+        # 6H, 6HX, 6HXX making exactly
+        self.assertEqual(980, calculate_score(6, BiddingSuit.HEARTS, 0, 12, False))
+        self.assertEqual(1210, calculate_score(6, BiddingSuit.HEARTS, 1, 12, False))
+        self.assertEqual(1620, calculate_score(6, BiddingSuit.HEARTS, 2, 12, False))
+        self.assertEqual(1430, calculate_score(6, BiddingSuit.HEARTS, 0, 12, True))
+        self.assertEqual(1660, calculate_score(6, BiddingSuit.HEARTS, 1, 12, True))
+        self.assertEqual(2070, calculate_score(6, BiddingSuit.HEARTS, 2, 12, True))
+
+        # 6H, 6HX, 6HXX making with an overtrick
+        self.assertEqual(1010, calculate_score(6, BiddingSuit.HEARTS, 0, 13, False))
+        self.assertEqual(1310, calculate_score(6, BiddingSuit.HEARTS, 1, 13, False))
+        self.assertEqual(1820, calculate_score(6, BiddingSuit.HEARTS, 2, 13, False))
+        self.assertEqual(1460, calculate_score(6, BiddingSuit.HEARTS, 0, 13, True))
+        self.assertEqual(1860, calculate_score(6, BiddingSuit.HEARTS, 1, 13, True))
+        self.assertEqual(2470, calculate_score(6, BiddingSuit.HEARTS, 2, 13, True))
+
+    def test_grand_minor_slam(self):
+        # 7D, 7DX, 7DXX making exactly
+        self.assertEqual(1440, calculate_score(7, BiddingSuit.DIAMONDS, 0, 13, False))
+        self.assertEqual(1630, calculate_score(7, BiddingSuit.DIAMONDS, 1, 13, False))
+        self.assertEqual(1960, calculate_score(7, BiddingSuit.DIAMONDS, 2, 13, False))
+        self.assertEqual(2140, calculate_score(7, BiddingSuit.DIAMONDS, 0, 13, True))
+        self.assertEqual(2330, calculate_score(7, BiddingSuit.DIAMONDS, 1, 13, True))
+        self.assertEqual(2660, calculate_score(7, BiddingSuit.DIAMONDS, 2, 13, True))
+
+    def test_undertricks(self):
+        # 7D, 7DX, 7DXX down 1
+        self.assertEqual(-50, calculate_score(7, BiddingSuit.DIAMONDS, 0, 12, False))
+        self.assertEqual(-100, calculate_score(7, BiddingSuit.DIAMONDS, 1, 12, False))
+        self.assertEqual(-200, calculate_score(7, BiddingSuit.DIAMONDS, 2, 12, False))
+        self.assertEqual(-100, calculate_score(7, BiddingSuit.DIAMONDS, 0, 12, True))
+        self.assertEqual(-200, calculate_score(7, BiddingSuit.DIAMONDS, 1, 12, True))
+        self.assertEqual(-400, calculate_score(7, BiddingSuit.DIAMONDS, 2, 12, True))
+
+        # 7D, 7DX, 7DXX down 2
+        self.assertEqual(-100, calculate_score(7, BiddingSuit.DIAMONDS, 0, 11, False))
+        self.assertEqual(-300, calculate_score(7, BiddingSuit.DIAMONDS, 1, 11, False))
+        self.assertEqual(-600, calculate_score(7, BiddingSuit.DIAMONDS, 2, 11, False))
+        self.assertEqual(-200, calculate_score(7, BiddingSuit.DIAMONDS, 0, 11, True))
+        self.assertEqual(-500, calculate_score(7, BiddingSuit.DIAMONDS, 1, 11, True))
+        self.assertEqual(-1000, calculate_score(7, BiddingSuit.DIAMONDS, 2, 11, True))
+
+        # 7D, 7DX, 7DXX down 3
+        self.assertEqual(-150, calculate_score(7, BiddingSuit.DIAMONDS, 0, 10, False))
+        self.assertEqual(-500, calculate_score(7, BiddingSuit.DIAMONDS, 1, 10, False))
+        self.assertEqual(-1000, calculate_score(7, BiddingSuit.DIAMONDS, 2, 10, False))
+        self.assertEqual(-300, calculate_score(7, BiddingSuit.DIAMONDS, 0, 10, True))
+        self.assertEqual(-800, calculate_score(7, BiddingSuit.DIAMONDS, 1, 10, True))
+        self.assertEqual(-1600, calculate_score(7, BiddingSuit.DIAMONDS, 2, 10, True))
+
+        # 7D, 7DX, 7DXX down 4
+        self.assertEqual(-200, calculate_score(7, BiddingSuit.DIAMONDS, 0, 9, False))
+        self.assertEqual(-800, calculate_score(7, BiddingSuit.DIAMONDS, 1, 9, False))
+        self.assertEqual(-1600, calculate_score(7, BiddingSuit.DIAMONDS, 2, 9, False))
+        self.assertEqual(-400, calculate_score(7, BiddingSuit.DIAMONDS, 0, 9, True))
+        self.assertEqual(-1100, calculate_score(7, BiddingSuit.DIAMONDS, 1, 9, True))
+        self.assertEqual(-2200, calculate_score(7, BiddingSuit.DIAMONDS, 2, 9, True))

--- a/bridgebots/tests/test_schemas.py
+++ b/bridgebots/tests/test_schemas.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from bridgebots import (
     BidMetadata,
@@ -14,6 +15,7 @@ from bridgebots import (
     DealSchema,
     Direction,
     deal_utils,
+    parse_single_lin,
 )
 
 
@@ -123,3 +125,9 @@ class TestSchemas(unittest.TestCase):
         loaded_deal_record = deal_record_schema.load(dumped_deal_record)
         self.assertEqual(self.deal, loaded_deal_record.deal)
         self.assertEqual(self.board_record, loaded_deal_record.board_records[0])
+
+    def test_missing_fields_schema(self):
+        results = parse_single_lin(Path(__file__).parent / "resources" / "sample.lin")
+        deal_record_schema = DealRecordSchema(many=True)
+        loaded_records = deal_record_schema.loads(deal_record_schema.dumps(results))
+        self.assertIsNone(loaded_records[0].board_records[0].commentary)

--- a/bridgebots/tests/test_schemas.py
+++ b/bridgebots/tests/test_schemas.py
@@ -1,16 +1,21 @@
 import unittest
 
-from bridgebots import deal_utils
-from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, Contract, DealRecord
-from bridgebots.deal import Card
-from bridgebots.deal_enums import BiddingSuit, Direction
-from bridgebots.schemas import (
+from bridgebots import (
+    BidMetadata,
     BidMetadataSchema,
+    BiddingSuit,
+    BoardRecord,
     BoardRecordSchema,
+    Card,
+    Commentary,
     CommentarySchema,
+    Contract,
     ContractSchema,
+    DealRecord,
     DealRecordSchema,
     DealSchema,
+    Direction,
+    deal_utils,
 )
 
 

--- a/bridgebots/tests/test_schemas.py
+++ b/bridgebots/tests/test_schemas.py
@@ -3,14 +3,12 @@ import unittest
 from bridgebots import (
     BidMetadata,
     BidMetadataSchema,
-    BiddingSuit,
     BoardRecord,
     BoardRecordSchema,
     Card,
     Commentary,
     CommentarySchema,
     Contract,
-    ContractSchema,
     DealRecord,
     DealRecordSchema,
     DealSchema,
@@ -96,13 +94,6 @@ class TestSchemas(unittest.TestCase):
         self.assertEqual(expected_bid_metadata, bid_metadata_schema.dump(bid_metadata))
         self.assertEqual(bid_metadata, bid_metadata_schema.load(expected_bid_metadata))
 
-    def test_contract_schema(self):
-        contract = Contract(2, BiddingSuit.DIAMONDS, 1)
-        contract_schema = ContractSchema()
-        expected_contract = {"level": 2, "suit": "D", "doubled": 1}
-        self.assertEqual(expected_contract, contract_schema.dump(contract))
-        self.assertEqual(contract, contract_schema.load(expected_contract))
-
     def test_board_record_schema(self):
         board_record_schema = BoardRecordSchema()
         expected_board_record = {
@@ -110,7 +101,7 @@ class TestSchemas(unittest.TestCase):
             "raw_bidding_record": ["p", "1H", "2N", "p", "3N", "p", "p", "p"],
             "play_record": self.play_record,
             "declarer": "N",
-            "contract": {"level": 3, "suit": "N", "doubled": 0},
+            "contract": "3N",
             "score": -150,
             "tricks": 6,
             "scoring": None,

--- a/bridgebots/tests/test_schemas.py
+++ b/bridgebots/tests/test_schemas.py
@@ -1,10 +1,17 @@
 import unittest
 
 from bridgebots import deal_utils
-from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, DealRecord
+from bridgebots.board_record import BidMetadata, BoardRecord, Commentary, Contract, DealRecord
 from bridgebots.deal import Card
-from bridgebots.deal_enums import Direction
-from bridgebots.schemas import BidMetadataSchema, BoardRecordSchema, CommentarySchema, DealRecordSchema, DealSchema
+from bridgebots.deal_enums import BiddingSuit, Direction
+from bridgebots.schemas import (
+    BidMetadataSchema,
+    BoardRecordSchema,
+    CommentarySchema,
+    ContractSchema,
+    DealRecordSchema,
+    DealSchema,
+)
 
 
 class TestSchemas(unittest.TestCase):
@@ -35,7 +42,8 @@ class TestSchemas(unittest.TestCase):
         raw_bidding_record=["p", "1H", "2N", "p", "3N", "p", "p", "p"],
         play_record=[Card.from_str(c) for c in play_record],
         declarer=Direction.NORTH,
-        contract="3NT",
+        contract=Contract.from_str("3NT"),
+        declarer_vulnerable=False,
         tricks=6,
         scoring=None,
         names={
@@ -83,6 +91,13 @@ class TestSchemas(unittest.TestCase):
         self.assertEqual(expected_bid_metadata, bid_metadata_schema.dump(bid_metadata))
         self.assertEqual(bid_metadata, bid_metadata_schema.load(expected_bid_metadata))
 
+    def test_contract_schema(self):
+        contract = Contract(2, BiddingSuit.DIAMONDS, 1)
+        contract_schema = ContractSchema()
+        expected_contract = {"level": 2, "suit": "D", "doubled": 1}
+        self.assertEqual(expected_contract, contract_schema.dump(contract))
+        self.assertEqual(contract, contract_schema.load(expected_contract))
+
     def test_board_record_schema(self):
         board_record_schema = BoardRecordSchema()
         expected_board_record = {
@@ -90,7 +105,8 @@ class TestSchemas(unittest.TestCase):
             "raw_bidding_record": ["p", "1H", "2N", "p", "3N", "p", "p", "p"],
             "play_record": self.play_record,
             "declarer": "N",
-            "contract": "3NT",
+            "contract": {"level": 3, "suit": "N", "doubled": 0},
+            "score": -150,
             "tricks": 6,
             "scoring": None,
             "names": {"N": "smalark", "S": "PrinceBen", "E": "granola357", "W": "Forrest_"},


### PR DESCRIPTION
## [0.0.7] - 2021-11-27
### Added
- Utility method `calculate_score` to compute the scoring of a hand
- `Contract` dataclass for programmatic interaction with contracts [Issue #6](https://github.com/forrestrice/bridge-bots/issues/6)
### Changed
- Methods which take each suit as an argument specify arguments in descending suit order (Spades, Hearts, Diamonds, Clubs) to match common convention. [Issue #7](https://github.com/forrestrice/bridge-bots/issues/7)
- Consolidated all submodule imports under `__init__.py`. Users can now simply `import bridgebots`. [Issue #8](https://github.com/forrestrice/bridge-bots/issues/8)
- All Record classes (BoardRecord, DealRecord, etc) now implemented as [dataclasses](https://docs.python.org/3/library/dataclasses.html). [Issue #9](https://github.com/forrestrice/bridge-bots/issues/9)

closes #6 #7 #8 #9 