### PR TITLE
Improvements to help parse vugraph project

### DIFF
--- a/bridgebots/CHANGELOG.md
+++ b/bridgebots/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.0.8] - 2022-1-15
+### Added
+`Direction.offset` Can be used to get the Direction an arbitrary number of steps away
+### Changed
+- Bridgebots now supports python 3.7! Several small backwards compatibility changes were made.
+- Fixed several edge case bugs for LIN parsing. Improved error messages.
+- `BiddingSuit.NO_TRUMP.abbreviation()` now returns `NT` by default. `N` can be returned by setting the flag `verbose_no_trump=False`
+
 ## [0.0.7] - 2021-11-27
 ### Added
 - Utility method `calculate_score` to compute the scoring of a hand

--- a/bridgebots/README.md
+++ b/bridgebots/README.md
@@ -31,7 +31,7 @@ Any added functionality should include unit tests.
 
 ## Guides
 There are a few introductory guides with detailed examples available.
-1. [Representing Bridge Components](https://forrestrice.com/posts/Announcing-Bridgebots/)
+1. [Representing Bridge Components](https://forrestrice.com/posts/Introducting-Bridgebots-Part-1/)
 2. [Deal/Board Records and PBN files](https://forrestrice.com/posts/Introducing-Bridgebots-Part-2/)
 3. [LIN files and JSON](https://forrestrice.com/posts/Introducing-Bridgebots-Part-3/)
 

--- a/bridgebots/bridgebots/bids.py
+++ b/bridgebots/bridgebots/bids.py
@@ -1,9 +1,7 @@
 from typing import Optional
 
-_LEGAL_BIDS = {
+LEGAL_BIDS = [
     "PASS",
-    "X",
-    "XX",
     "1C",
     "1D",
     "1H",
@@ -39,7 +37,11 @@ _LEGAL_BIDS = {
     "7H",
     "7S",
     "7NT",
-}
+    "X",
+    "XX",
+]
+
+_LEGAL_BIDS_SET = set(LEGAL_BIDS)
 
 
 def canonicalize_bid(bid: str) -> Optional[str]:
@@ -52,4 +54,4 @@ def canonicalize_bid(bid: str) -> Optional[str]:
         bid = "XX"
     elif bid == "P":
         bid = "PASS"
-    return bid if bid in _LEGAL_BIDS else None
+    return bid if bid in _LEGAL_BIDS_SET else None

--- a/bridgebots/bridgebots/board_record.py
+++ b/bridgebots/bridgebots/board_record.py
@@ -42,14 +42,19 @@ class Contract:
 
     @staticmethod
     def from_str(contract: str) -> Contract:
-        if contract == "PASS":
-            return Contract(0, None, 0)
-        doubled = contract.count("X")
-        if doubled > 0:
-            contract = contract.replace("X", "")
-        level = int(contract[0])
-        suit = BiddingSuit.from_str(contract[1:])
-        return Contract(level, suit, doubled)
+        working_contract = contract
+        try:
+            if working_contract == "PASS":
+                return Contract(0, None, 0)
+            doubled = working_contract.count("X")
+            if doubled > 0:
+                working_contract = working_contract.replace("X", "")
+            level = int(working_contract[0])
+            suit = BiddingSuit.from_str(working_contract[1:])
+            return Contract(level, suit, doubled)
+        except (ValueError, IndexError) as e:
+            raise ValueError(f"Invalid Contract: {contract}") from e
+
 
     def __str__(self):
         if self.level == 0:

--- a/bridgebots/bridgebots/board_record.py
+++ b/bridgebots/bridgebots/board_record.py
@@ -36,6 +36,11 @@ class Commentary:
 
 @dataclass(frozen=True)
 class Contract:
+    """
+    The final contract of a played board. Includes level (6 in 6NT), Bidding Suit (None if passed out), and number of
+    times the contract was doubled
+    """
+
     level: int
     suit: Optional[BiddingSuit]
     doubled: int
@@ -52,9 +57,8 @@ class Contract:
             level = int(working_contract[0])
             suit = BiddingSuit.from_str(working_contract[1:])
             return Contract(level, suit, doubled)
-        except (ValueError, IndexError) as e:
+        except (ValueError, IndexError, KeyError) as e:
             raise ValueError(f"Invalid Contract: {contract}") from e
-
 
     def __str__(self):
         if self.level == 0:

--- a/bridgebots/bridgebots/deal_enums.py
+++ b/bridgebots/bridgebots/deal_enums.py
@@ -39,7 +39,6 @@ class Direction(Enum):
     def offset(self, offset: int) -> Direction:
         return Direction((self.value + offset) % 4)
 
-
     def abbreviation(self) -> str:
         return self.name[0]
 
@@ -86,7 +85,9 @@ class BiddingSuit(Enum):
     def to_suit(self) -> Suit:
         return self.value[1]
 
-    def abbreviation(self) -> str:
+    def abbreviation(self, verbose_no_trump=True) -> str:
+        if self.value == BiddingSuit.NO_TRUMP.value and verbose_no_trump:
+            return "NT"
         return self.name[0]
 
     @classmethod

--- a/bridgebots/bridgebots/deal_enums.py
+++ b/bridgebots/bridgebots/deal_enums.py
@@ -28,13 +28,17 @@ class Direction(Enum):
         return self.name
 
     def next(self) -> Direction:
-        return Direction((self.value + 1) % 4)
+        return self.offset(1)
 
     def partner(self) -> Direction:
-        return Direction((self.value + 2) % 4)
+        return self.offset(2)
 
     def previous(self) -> Direction:
-        return Direction((self.value + 3) % 4)
+        return self.offset(3)
+
+    def offset(self, offset: int) -> Direction:
+        return Direction((self.value + offset) % 4)
+
 
     def abbreviation(self) -> str:
         return self.name[0]

--- a/bridgebots/bridgebots/deal_utils.py
+++ b/bridgebots/bridgebots/deal_utils.py
@@ -1,4 +1,3 @@
-import re
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -12,7 +11,6 @@ _NS_VULNERABLE_STRINGS = {"Both", "N-S", "All", "NS", "b", "n"}
 _EW_VULNERABLE_STRINGS = {"Both", "E-W", "All", "EW", "b", "e"}
 _REVERSE_SORTED_CARDS = sorted([Card(suit, rank) for suit in Suit for rank in Rank], reverse=True)
 _LIN_DEALER_TO_DIRECTION = {"1": Direction.SOUTH, "2": Direction.WEST, "3": Direction.NORTH, "4": Direction.EAST}
-_SUIT_CHAR_REGEX = re.compile("[SHDC]")
 _HOLDING_SUIT_IDENTIFIERS = ["S", "H", "D", "C"]
 _DECK_SET = frozenset({Card(suit, rank) for rank in Rank for suit in Suit})
 _RANK_HCP = {Rank.ACE: 4, Rank.KING: 3, Rank.QUEEN: 2, Rank.JACK: 1}
@@ -166,4 +164,5 @@ def from_lin_deal(lin_dealer_str: str, vulnerability_str: str, holdings_str: str
 
 
 def count_hcp(cards: List[Card]) -> int:
+    """:return Goren High Card Points for a list of cards"""
     return sum((_RANK_HCP.get(c.rank, 0) for c in cards))

--- a/bridgebots/bridgebots/deal_utils.py
+++ b/bridgebots/bridgebots/deal_utils.py
@@ -13,6 +13,7 @@ _EW_VULNERABLE_STRINGS = {"Both", "E-W", "All", "EW", "b", "e"}
 _REVERSE_SORTED_CARDS = sorted([Card(suit, rank) for suit in Suit for rank in Rank], reverse=True)
 _LIN_DEALER_TO_DIRECTION = {"1": Direction.SOUTH, "2": Direction.WEST, "3": Direction.NORTH, "4": Direction.EAST}
 _SUIT_CHAR_REGEX = re.compile("[SHDC]")
+_HOLDING_SUIT_IDENTIFIERS = ["S", "H", "D", "C"]
 _DECK_SET = frozenset({Card(suit, rank) for rank in Rank for suit in Suit})
 
 
@@ -114,6 +115,24 @@ def from_pbn_deal(dealer_str: str, vulnerability_str: str, deal_str: str) -> Dea
     return Deal(dealer, ns_vulnerable, ew_vulnerable, player_hands)
 
 
+def _parse_lin_holding(holding: str) -> List[List[str]]:
+    suit_holdings = []
+    holding_index = 0
+    for id in _HOLDING_SUIT_IDENTIFIERS:
+        suit_holding = []
+        while holding_index < len(holding):
+            c = holding[holding_index]
+            if c == id:
+                holding_index += 1
+                continue
+            if c in _HOLDING_SUIT_IDENTIFIERS:
+                break
+            suit_holding.append(c)
+            holding_index += 1
+        suit_holdings.append(suit_holding)
+    return suit_holdings
+
+
 def from_lin_deal(lin_dealer_str: str, vulnerability_str: str, holdings_str: str) -> Deal:
     """
     Convert LIN deal nodes into a bridgebots deal
@@ -125,7 +144,7 @@ def from_lin_deal(lin_dealer_str: str, vulnerability_str: str, holdings_str: str
     dealer = _LIN_DEALER_TO_DIRECTION[lin_dealer_str]
     holdings = holdings_str.strip(",").split(",")
     # Convert a holding string like SA63HJ8642DK53CKJ into a PlayerHand
-    players_suit_holdings = [_SUIT_CHAR_REGEX.split(holding)[1:] for holding in holdings]
+    players_suit_holdings = [_parse_lin_holding(holding) for holding in holdings]
     player_hands = {}
     current_direction = Direction.SOUTH
     for suit_holdings in players_suit_holdings:

--- a/bridgebots/bridgebots/deal_utils.py
+++ b/bridgebots/bridgebots/deal_utils.py
@@ -15,6 +15,7 @@ _LIN_DEALER_TO_DIRECTION = {"1": Direction.SOUTH, "2": Direction.WEST, "3": Dire
 _SUIT_CHAR_REGEX = re.compile("[SHDC]")
 _HOLDING_SUIT_IDENTIFIERS = ["S", "H", "D", "C"]
 _DECK_SET = frozenset({Card(suit, rank) for rank in Rank for suit in Suit})
+_RANK_HCP = {Rank.ACE: 4, Rank.KING: 3, Rank.QUEEN: 2, Rank.JACK: 1}
 
 
 def serialize_deal(deal: Deal) -> bytes:
@@ -162,3 +163,7 @@ def from_lin_deal(lin_dealer_str: str, vulnerability_str: str, holdings_str: str
     ew_vulnerable = vulnerability_str in _EW_VULNERABLE_STRINGS
     deal = Deal(dealer, ns_vulnerable, ew_vulnerable, player_hands)
     return deal
+
+
+def count_hcp(cards: List[Card]) -> int:
+    return sum((_RANK_HCP.get(c.rank, 0) for c in cards))

--- a/bridgebots/bridgebots/lin.py
+++ b/bridgebots/bridgebots/lin.py
@@ -223,10 +223,12 @@ def _build_play_str(board_record: BoardRecord) -> str:
 
 def combine_header(file) -> str:
     combined = ""
-    while line := file.readline():
+    line = file.readline()
+    while line:
         combined += line.replace("\n", "")
         if combined.endswith("|pg||"):
             return combined
+        line = file.readline()
     #TODO not unicode
     raise UnicodeError(f"Invalid multi-lin header in file: {file}")
 

--- a/bridgebots/bridgebots/lin.py
+++ b/bridgebots/bridgebots/lin.py
@@ -221,6 +221,7 @@ def _build_play_str(board_record: BoardRecord) -> str:
         play_str += f"mc|{board_record.tricks}|"
     return play_str
 
+
 def combine_header(file) -> str:
     combined = ""
     line = file.readline()
@@ -229,9 +230,7 @@ def combine_header(file) -> str:
         if combined.endswith("|pg||"):
             return combined
         line = file.readline()
-    #TODO not unicode
-    raise UnicodeError(f"Invalid multi-lin header in file: {file}")
-
+    raise ValueError(f"Invalid multi-lin header in file: {file}")
 
 
 def parse_single_lin(file_path: Path) -> List[DealRecord]:
@@ -260,17 +259,6 @@ def parse_multi_lin(file_path: Path) -> List[DealRecord]:
     with open(file_path) as lin_file:
         header = combine_header(lin_file)
         parsed_header = _parse_lin_string(header)
-        '''
-        first_line = lin_file.readline()
-        if not first_line:
-            raise UnicodeError("no content") #TODO not unicode
-        if first_line.lower() == "pf|y|\n":
-            title_line = lin_file.readline()
-        else:
-            title_line = first_line
-        results = _parse_lin_string(lin_file.readline())
-        player_names = _parse_lin_string(combine_lines(lin_file))
-        '''
         board_strings = []
         current_board = ""
         for line in lin_file:

--- a/bridgebots/bridgebots/pbn.py
+++ b/bridgebots/bridgebots/pbn.py
@@ -221,12 +221,14 @@ def _parse_board_record(record_dict: Dict, deal: Deal) -> BoardRecord:
     play_record_strings = record_dict.get("play_record") or []
     play_record = _sort_play_record(play_record_strings, record_dict["Contract"])
 
-    if not (result_str := record_dict.get("Result")):
+    result_str = record_dict.get("Result")
+    if not result_str:
         message = f"Missing tricks result: {result_str}"
         logging.warning(message)
         raise ValueError(message)
 
-    if not (contract_str := record_dict.get("Contract")):
+    contract_str = record_dict.get("Contract")
+    if not contract_str:
         message = f"Missing contract: {contract_str}"
         logging.warning(message)
         raise ValueError(message)

--- a/bridgebots/pyproject.toml
+++ b/bridgebots/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "bridgebots"
-version = "0.0.7"
+version = "0.0.8-dev"
 description = "Data processing for Contract Bridge"
 authors = ["Forrest Rice <forrest.d.rice@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 marshmallow = "^3.12.1"
 
 [tool.poetry.dev-dependencies]

--- a/bridgebots/pyproject.toml
+++ b/bridgebots/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bridgebots"
-version = "0.0.8-dev"
+version = "0.0.9-dev"
 description = "Data processing for Contract Bridge"
 authors = ["Forrest Rice <forrest.d.rice@gmail.com>"]
 license = "MIT"

--- a/bridgebots/tests/test_board_record.py
+++ b/bridgebots/tests/test_board_record.py
@@ -1,0 +1,25 @@
+import unittest
+
+from bridgebots import BiddingSuit, Contract
+
+
+class TestContract(unittest.TestCase):
+    def test_contract_from_str(self):
+        self.assertEqual(Contract(0, None, 0), Contract.from_str("PASS"))
+        self.assertEqual(Contract(3, BiddingSuit.CLUBS, 0), Contract.from_str("3C"))
+        self.assertEqual(Contract(2, BiddingSuit.NO_TRUMP, 1), Contract.from_str("2NTX"))
+        self.assertEqual(Contract(6, BiddingSuit.DIAMONDS, 2), Contract.from_str("6DXX"))
+
+    def test_contract_to_str(self):
+        self.assertEqual("PASS", str(Contract(0, None, 0)))
+        self.assertEqual("3C", str(Contract(3, BiddingSuit.CLUBS, 0)))
+        self.assertEqual("2NTX", str(Contract(2, BiddingSuit.NO_TRUMP, 1)))
+        self.assertEqual("6DXX", str(Contract(6, BiddingSuit.DIAMONDS, 2)))
+
+    def test_invalid_contract(self):
+        with self.assertRaises(ValueError):
+            Contract.from_str("")
+        with self.assertRaises(ValueError):
+            Contract.from_str("3")
+        with self.assertRaises(ValueError):
+            Contract.from_str("3Z")

--- a/bridgebots/tests/test_deal_utils.py
+++ b/bridgebots/tests/test_deal_utils.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 from bridgebots import Deal, Direction, PlayerHand, Suit, deal_utils, from_acbl_dict
+from bridgebots.deal_utils import _parse_lin_holding
 
 
 class TestAcblDeal(unittest.TestCase):
@@ -66,3 +67,34 @@ class TestBinaryDeal(unittest.TestCase):
         binary_deal = deal_utils.serialize_deal(TestBinaryDeal.test_deal)
         out_deal = deal_utils.deserialize_deal(binary_deal)
         self.assertEqual(TestBinaryDeal.test_deal, out_deal)
+
+
+class TestLinDeal(unittest.TestCase):
+    def test_parse_lin_holding_normal(self):
+        holding = "SAK7HJ6DJ3CQ98654"
+        self.assertEqual(
+            [["A", "K", "7"], ["J", "6"], ["J", "3"], ["Q", "9", "8", "6", "5", "4"]], _parse_lin_holding(holding)
+        )
+
+    def test_parse_lin_holding_missing_spades(self):
+        holding = "HAKJ76DJ3CQ98654"
+        self.assertEqual(
+            [[], ["A", "K", "J", "7", "6"], ["J", "3"], ["Q", "9", "8", "6", "5", "4"]], _parse_lin_holding(holding)
+        )
+
+    def test_parse_lin_holding_missing_clubs(self):
+        holding = "SAK7HJ6DQJ986543"
+        self.assertEqual(
+            [["A", "K", "7"], ["J", "6"], ["Q", "J", "9", "8", "6", "5", "4", "3"], []], _parse_lin_holding(holding)
+        )
+
+    def test_parse_lin_holding_missing_red_suits(self):
+        holding = "SAK7DQJ63CQ98654"
+        self.assertEqual(
+            [["A", "K", "7"], [], ["Q", "J", "6", "3"], ["Q", "9", "8", "6", "5", "4"]], _parse_lin_holding(holding)
+        )
+
+        holding = "SAK7HJ654CQ98654"
+        self.assertEqual(
+            [["A", "K", "7"], ["J", "6", "5", "4"], [], ["Q", "9", "8", "6", "5", "4"]], _parse_lin_holding(holding)
+        )

--- a/bridgebots/tests/test_lin.py
+++ b/bridgebots/tests/test_lin.py
@@ -106,6 +106,8 @@ class TestParseLin(unittest.TestCase):
         raw_bidding_record = ["5C", "p", "p", "d", "p", "p", "r", "p", "p", "p"]
         bidding_record, bidding_metadata, contract = _parse_bidding_record(raw_bidding_record, {})
         self.assertEqual(["5C", "PASS", "PASS", "X", "PASS", "PASS", "XX", "PASS", "PASS", "PASS"], bidding_record)
+        self.assertEqual([], bidding_metadata)
+        self.assertEqual("5CXX", contract)
 
     def test_determine_declarer(self):
         deal = _parse_deal({"md": ["1SQ982HQ82DKQ763CT,SJ643HKJ7653DCAQ4,SK5HADAJT52CJ9762,"], "sv": ["e"]})

--- a/bridgebots/tests/test_lin.py
+++ b/bridgebots/tests/test_lin.py
@@ -102,11 +102,19 @@ class TestParseLin(unittest.TestCase):
         ]
         self.assertEqual(expected_bidding_metadata, bidding_metadata)
 
+    def test_parse_contract(self):
+        raw_bidding_record = ["5C", "p", "p", "d", "p", "p", "r", "p", "p", "p"]
+        bidding_record, bidding_metadata, contract = _parse_bidding_record(raw_bidding_record, {})
+        self.assertEqual(["5C", "PASS", "PASS", "X", "PASS", "PASS", "XX", "PASS", "PASS", "PASS"], bidding_record)
+
     def test_determine_declarer(self):
         deal = _parse_deal({"md": ["1SQ982HQ82DKQ763CT,SJ643HKJ7653DCAQ4,SK5HADAJT52CJ9762,"], "sv": ["e"]})
         bidding_record = ["PASS", "PASS", "1D", "PASS", "1S", "2H", "3C", "PASS", "3D", "PASS", "PASS", "PASS"]
         play_record = [Card.from_str("SA")]
         self.assertEqual(Direction.NORTH, _determine_declarer(play_record, bidding_record, deal))
+
+    def test_parse_tricks_with_passout(self):
+        self.assertEqual(0, _parse_tricks({}, Direction.EAST, "PASS", []))
 
     def test_parse_tricks_with_claim(self):
         self.assertEqual(10, _parse_tricks({"mc": ["10"]}, Direction.NORTH, "2S", []))

--- a/bridgebots/tests/test_schemas.py
+++ b/bridgebots/tests/test_schemas.py
@@ -103,7 +103,7 @@ class TestSchemas(unittest.TestCase):
             "raw_bidding_record": ["p", "1H", "2N", "p", "3N", "p", "p", "p"],
             "play_record": self.play_record,
             "declarer": "N",
-            "contract": "3N",
+            "contract": "3NT",
             "score": -150,
             "tricks": 6,
             "scoring": None,

--- a/parse/parse_vugraph_project.py
+++ b/parse/parse_vugraph_project.py
@@ -9,12 +9,11 @@ logging.basicConfig(level=logging.DEBUG)
 
 # /Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2013/nec/rr10b.lin
 # "/Users/frice/bridge/vugraph_project/"
-#test_path="/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2015/wbc/rr134.lin"
-#parse_multi_lin(Path(test_path))
+# test_path="/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2015/wbc/rr134.lin"
+test_path = "/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2004/cav/p4.lin"
+parse_multi_lin(Path(test_path))
 all_results = []
-for results_path in Path("/Users/frice/bridge/vugraph_project/").rglob(
-    "*.lin"
-):
+for results_path in Path("/Users/frice/bridge/vugraph_project/").rglob("*.lin"):
     logging.debug(f"results_path: {str(results_path)}")
     try:
         file_results = parse_multi_lin(results_path)

--- a/parse/parse_vugraph_project.py
+++ b/parse/parse_vugraph_project.py
@@ -5,13 +5,10 @@ from pathlib import Path
 
 from bridgebots import DealRecord, parse_multi_lin
 
+"""Consume all downloaded LIN files from the vugraph project (https://www.sarantakos.com/bridge/vugraph.html) and write 
+them to a pickle file"""
 logging.basicConfig(level=logging.DEBUG)
 
-# /Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2013/nec/rr10b.lin
-# "/Users/frice/bridge/vugraph_project/"
-# test_path="/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2015/wbc/rr134.lin"
-test_path = "/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2004/cav/p4.lin"
-parse_multi_lin(Path(test_path))
 all_results = []
 for results_path in Path("/Users/frice/bridge/vugraph_project/").rglob("*.lin"):
     logging.debug(f"results_path: {str(results_path)}")

--- a/parse/parse_vugraph_project.py
+++ b/parse/parse_vugraph_project.py
@@ -3,16 +3,25 @@ import pickle
 from collections import defaultdict
 from pathlib import Path
 
-from bridgebots.board_record import DealRecord
-from bridgebots.pbn import parse_pbn
+from bridgebots import DealRecord, parse_multi_lin
 
 logging.basicConfig(level=logging.DEBUG)
 
+# /Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2013/nec/rr10b.lin
+# "/Users/frice/bridge/vugraph_project/"
+#test_path="/Users/frice/bridge/vugraph_project/www.sarantakos.com/bridge/vugraph/2015/wbc/rr134.lin"
+#parse_multi_lin(Path(test_path))
 all_results = []
-for results_path in Path("/Users/frice/bridge/results/").rglob("*.pbn"):
-    file_results = parse_pbn(results_path)
-    all_results.extend(file_results)
-    logging.debug(f"extracted {len(file_results)} results from {results_path}")
+for results_path in Path("/Users/frice/bridge/vugraph_project/").rglob(
+    "*.lin"
+):
+    logging.debug(f"results_path: {str(results_path)}")
+    try:
+        file_results = parse_multi_lin(results_path)
+        all_results.extend(file_results)
+        logging.debug(f"extracted {len(file_results)} results from {results_path}")
+    except UnicodeError as e:
+        logging.error(e)
 
 logging.info(f"{len(all_results)} total results")
 
@@ -23,7 +32,7 @@ for deal_record in all_results:
 
 deduped_results = [DealRecord(deal, list(board_records)) for deal, board_records in deal_dict.items()]
 
-pickle_file_path = "/Users/frice/bridge/results/major_tournaments_pbn.pickle"
+pickle_file_path = "/Users/frice/bridge/vugraph_project/all_deals.pickle"
 with open(pickle_file_path, "wb") as pickle_file:
     pickle.dump(deduped_results, pickle_file)
 


### PR DESCRIPTION
# Bridgebots Core
## [0.0.8] - 2022-1-15
### Added
`Direction.offset` Can be used to get the Direction an arbitrary number of steps away
### Changed
- Bridgebots now supports python 3.7! Several small backwards compatibility changes were made.
- Fixed several edge case bugs for LIN parsing. Improved error messages.
- `BiddingSuit.NO_TRUMP.abbreviation()` now returns `NT` by default. `N` can be returned by setting the flag `verbose_no_trump=False`

# Parse Module
Added a script to parse the vugraph project downloads and create a pickle file of all DealRecords.