### PR TITLE
Parse paired PBN files

### DIFF
--- a/bridgebots/CHANGELOG.md
+++ b/bridgebots/CHANGELOG.md
@@ -1,38 +1,43 @@
 # Changelog
 
+## [0.0.9] - 2022-1-16
+### Added
+- `parse_pbn` now handles files which used shared deals for multiple board records.
+- `parse_pbn` now handles files that end with a single newline.
+
 ## [0.0.8] - 2022-1-15
 ### Added
-`Direction.offset` Can be used to get the Direction an arbitrary number of steps away
+- `Direction.offset` Can be used to get the Direction an arbitrary number of steps away.
 ### Changed
 - Bridgebots now supports python 3.7! Several small backwards compatibility changes were made.
 - Fixed several edge case bugs for LIN parsing. Improved error messages.
-- `BiddingSuit.NO_TRUMP.abbreviation()` now returns `NT` by default. `N` can be returned by setting the flag `verbose_no_trump=False`
+- `BiddingSuit.NO_TRUMP.abbreviation()` now returns `NT` by default. `N` can be returned by setting the flag `verbose_no_trump=False`.
 
 ## [0.0.7] - 2021-11-27
 ### Added
-- Utility method `calculate_score` to compute the scoring of a hand
-- `Contract` dataclass for programmatic interaction with contracts [Issue #6](https://github.com/forrestrice/bridge-bots/issues/6)
+- Utility method `calculate_score` to compute the scoring of a hand.
+- `Contract` dataclass for programmatic interaction with contracts [Issue #6](https://github.com/forrestrice/bridge-bots/issues/6).
 ### Changed
-- Methods which take each suit as an argument specify arguments in descending suit order (Spades, Hearts, Diamonds, Clubs) to match common convention. [Issue #7](https://github.com/forrestrice/bridge-bots/issues/7)
-- Consolidated all submodule imports under `__init__.py`. Users can now simply `import bridgebots`. [Issue #8](https://github.com/forrestrice/bridge-bots/issues/8)
-- All Record classes (BoardRecord, DealRecord, etc) now implemented as [dataclasses](https://docs.python.org/3/library/dataclasses.html). [Issue #9](https://github.com/forrestrice/bridge-bots/issues/9)
+- Methods which take each suit as an argument specify arguments in descending suit order (Spades, Hearts, Diamonds, Clubs) to match common convention. [Issue #7](https://github.com/forrestrice/bridge-bots/issues/7).
+- Consolidated all submodule imports under `__init__.py`. Users can now simply `import bridgebots`. [Issue #8](https://github.com/forrestrice/bridge-bots/issues/8).
+- All Record classes (BoardRecord, DealRecord, etc) now implemented as [dataclasses](https://docs.python.org/3/library/dataclasses.html). [Issue #9](https://github.com/forrestrice/bridge-bots/issues/9).
 
 
 ## [0.0.6] - 2021-09-06
 ### Changed
-- BoardRecord and BoardRecord schema have better handling of missing commentary or bidding metadata
+- BoardRecord and BoardRecord schema have better handling of missing commentary or bidding metadata.
 
 ## [0.0.5] - 2021-09-06
 ### Changed
-- BoardRecord now represents player names as a Direction:String dictionary
+- BoardRecord now represents player names as a Direction:String dictionary.
 
 ## [0.0.4] - 2021-08-29
 ### Added
-- Support for parsing and creating LIN files
-- Marshmallow schemas for marshalling to/from JSON
-- Support for parsing PBN commentary, notes, and alerts
-- Readme with examples
+- Support for parsing and creating LIN files.
+- Marshmallow schemas for marshalling to/from JSON.
+- Support for parsing PBN commentary, notes, and alerts.
+- Readme with examples.
 
 ### Changed
 
-- \_\_repr\_\_ for most Bridgebots Core classes updated to be more explanatory and/or less verbose
+- \_\_repr\_\_ for most Bridgebots Core classes updated to be more explanatory and/or less verbose.

--- a/bridgebots/pyproject.toml
+++ b/bridgebots/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bridgebots"
-version = "0.0.9-dev"
+version = "0.0.9"
 description = "Data processing for Contract Bridge"
 authors = ["Forrest Rice <forrest.d.rice@gmail.com>"]
 license = "MIT"

--- a/bridgebots/tests/resources/sample.pbn
+++ b/bridgebots/tests/resources/sample.pbn
@@ -119,4 +119,3 @@ D2 SA S3 S5
 [HomeTeam "Brazil"]
 [VisitTeam "France"]
 [Room "Open"]
-

--- a/bridgebots/tests/resources/shared_deals.pbn
+++ b/bridgebots/tests/resources/shared_deals.pbn
@@ -1,0 +1,91 @@
+% PBN (c) 2021 rpbridge.net
+[Date "2014.07.??"]
+[Event "Spingold"]
+[Stage "Final:4"]
+[HomeTeam "Monaco"]
+[VisitTeam "Schwartz"]
+[West "Brogeland"]
+[North "Helness"]
+[East "Lindqvist"]
+[South "Helgemo"]
+[Board "62"]
+[Dealer "E"]
+[Vulnerable "None"]
+[Deal "W:KT32.Q9743.QT2.Q 6..A65.AKT987542 AQJ954.K.973.J63 87.AJT8652.KJ84."]
+[Declarer "N"]
+[Contract "6C"]
+[Result "11"]
+[Auction "E"]
+1S 3H 4S 6C
+AP
+[Play "E"]
+SA S7 S2 S6
+SQ S8 S3 C2
+C3 H2 CQ CA
+H5 H3 CK C6
+*
+
+[West "Nunes"]
+[North "SchwartzO"]
+[East "Fantoni"]
+[South "FisherL"]
+[Declarer "E"]
+[Contract "6SX"]
+[Result "9"]
+[Auction "E"]
+2S 3H 4S 6C
+Pass Pass 6S X
+AP
+[Play "S"]
+HA H3 CT HK
+D4 D2 DA D7
+H2 CQ CA C3
+DK DT D6 D3
+D8 DQ D5 D9
+S7 S2 S6 SQ
+*
+
+[Date "2014.07.??"]
+[Event "Spingold"]
+[Stage "SemiF:1"]
+[HomeTeam "Lavazza"]
+[VisitTeam "Monaco"]
+[West "Helgemo"]
+[North "Bocchi"]
+[East "Helness"]
+[South "Madala"]
+[Board "7"]
+[Dealer "S"]
+[Vulnerable "Both"]
+[Deal "W:T.A94.84.KQJ9753 94.QJT865.QJT7.8 KQ852.K.AK63.A62 AJ763.732.952.T4"]
+[Declarer "W"]
+[Contract "6N"]
+[Result "12"]
+[Auction "S"]
+1C 1H X 2H
+3C Pass 3H Pass
+3NT Pass 4C Pass
+4H Pass 4S X
+5C Pass 6NT AP
+[Play "N"]
+HQ - - -
+*
+
+[West "Zia"]
+[North "Zimmerm."]
+[East "Bianchedi"]
+[South "Multon"]
+[Declarer "W"]
+[Contract "6C"]
+[Result "12"]
+[Auction "S"]
+1C 3H 3S Pass
+4C Pass 4NT Pass
+5S Pass 6C AP
+[Play "N"]
+DQ DA D2 D4
+C8 C2 C4 CJ
+CK H8 C6 CT
+S4 SK SA ST
+*
+

--- a/bridgebots/tests/test_pbn.py
+++ b/bridgebots/tests/test_pbn.py
@@ -1,7 +1,7 @@
 import unittest
 from pathlib import Path
 
-from bridgebots import BidMetadata, BiddingSuit, Contract, Direction, Rank, Suit, parse_pbn
+from bridgebots import BidMetadata, BiddingSuit, Card, Contract, Direction, Rank, Suit, parse_pbn
 from bridgebots.pbn import _build_record_dict, _parse_bidding_record, _sort_play_record
 
 
@@ -19,24 +19,14 @@ class TestParsePbnFile(unittest.TestCase):
             [Rank.KING, Rank.QUEEN, Rank.JACK, Rank.SEVEN], deal_1.hands[Direction.EAST].suits[Suit.SPADES]
         )
         self.assertEqual(
+            # fmt: off
             [
-                "1H",
-                "Pass",
-                "1S",
-                "=1=",
-                "Pass",
-                "2C",
-                "!",
-                "Pass",
-                "2H",
-                "=2=",
-                "Pass",
-                "2S",
-                "=3=",
-                "Pass",
-                "3NT",
+                "1H", "Pass", "1S", "=1=", "Pass",
+                "2C", "!", "Pass", "2H", "=2=", "Pass",
+                "2S", "=3=", "Pass", "3NT",
                 "AP",
             ],
+            # fmt: on
             board_record_1.raw_bidding_record,
         )
 
@@ -56,37 +46,18 @@ class TestParsePbnFile(unittest.TestCase):
         )
 
         self.assertEqual(
+            # fmt: off
             [
-                "CQ",
-                "CA",
-                "C8",
-                "C3",
-                "H4",
-                "HT",
-                "HK",
-                "H6",
-                "H3",
-                "H2",
-                "HQ",
-                "HA",
-                "C5",
-                "C6",
-                "CK",
-                "CT",
-                "D4",
-                "DJ",
-                "DQ",
-                "DK",
-                "CJ",
-                "C2",
-                "S7",
-                "C7",
-                "C9",
-                "C4",
-                "H5",
-                "S4",
+                "CQ", "CA", "C8", "C3",
+                "H4", "HT", "HK", "H6",
+                "H3", "H2", "HQ", "HA",
+                "C5", "C6", "CK", "CT",
+                "D4", "DJ", "DQ", "DK",
+                "CJ", "C2", "S7", "C7",
+                "C9", "C4", "H5", "S4",
                 "S6",
             ],
+            # fmt: on
             [str(card) for card in board_record_1.play_record],
         )
         self.assertEqual(Direction.WEST, board_record_1.declarer)
@@ -118,6 +89,14 @@ class TestParsePbnFile(unittest.TestCase):
         self.assertEqual(board_record_2.names[Direction.SOUTH], "Bauke Muller")
         self.assertEqual(board_record_2.names[Direction.EAST], "Denny Sacul")
         self.assertEqual(board_record_2.names[Direction.WEST], "Franky Karwur")
+
+    def test_parse_shared_deals_file(self):
+        sample_pbn_path = Path(__file__).parent / "resources" / "shared_deals.pbn"
+        records = parse_pbn(sample_pbn_path)
+        self.assertEqual(2, len(records))
+        self.assertEqual(4, sum(len(deal_record.board_records) for deal_record in records))
+        self.assertEqual(Card.from_str("SA"), records[0].board_records[0].play_record[0])
+        self.assertEqual(Card.from_str("HA"), records[0].board_records[1].play_record[0])
 
 
 class TestPbnRecordDict(unittest.TestCase):


### PR DESCRIPTION
## [0.0.9] - 2022-1-16
### Added
- `parse_pbn` now handles files which used shared deals for multiple board records.
- `parse_pbn` now handles files that end with a single newline.